### PR TITLE
Round of grid cleanup

### DIFF
--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -7,6 +7,7 @@
 // .c-button--xs - Two steps down from default
 // .c-button--circle - Circular button (experimentally used for back to top)
 // .c-button--outline - Hover effect of outline (used on social)
+// .c-button--compact - Removes vertical padding (used on social)
 //
 // Markup: 6-components/button/button.html
 //
@@ -72,6 +73,11 @@
         }
       }
     }
+  }
+
+  &--compact {
+    padding-top: 0;
+    padding-bottom: 0;
   }
 }
 

--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -29,15 +29,15 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
   }
 
 
-  ul {
+  > ul {
     list-style: disc;
     padding: 0 $size-b 0 3.5rem;
-    
+
+    li {
+      margin-bottom: $size-b;
+    }
   }
 
-  li {
-    margin-bottom: $size-b;
-  }
 
   sub, sup {
     position: initial;

--- a/assets/scss/7-layout/_grid-legacy.scss
+++ b/assets/scss/7-layout/_grid-legacy.scss
@@ -38,13 +38,13 @@
 //
 // Deprecated: Adds side padding at various viewport widths. Note: Demo is best viewed in [standalone preview](/pages/layout/grid_padded/raw-preview.html). {{isHelper}}
 //
-// .grid_padded - Gutter padding:<br>`.92rem` mobile<br> `1.1rem` tablet - desktop <br>`0` large desktop
-// .grid_padded--temp - Gutter padding:<br>`0` mobile - small desktop<br>`1.1rem` desktop<br>`0` large desktop
-// .grid_padded--s - Gutter padding:<br>`1.1rem` mobile<br>`0` tablet+
-// .grid_padded--m - Gutter padding:<br>`1.1rem` tablet<br>`0` small desktop+
-// .grid_padded--l - Gutter padding:<br>`1.1rem` small desktop<br>`0` desktop+
-// .grid_padded--xl - Gutter padding:<br>`1.1rem` desktop<br>`0` large desktop+
-// .grid_padded--xxl - Gutter padding:<br>`1.1rem` large desktop<br>`0` large desktop+
+// .grid_padded - Left/right padding:<br>`.92rem` mobile<br> `1.1rem` tablet - desktop <br>`0` large desktop
+// .grid_padded--temp - Left/right padding:<br>`0` mobile - small desktop<br>`1.1rem` desktop<br>`0` large desktop
+// .grid_padded--s - Left/right padding:<br>`1.1rem` mobile<br>`0` tablet+
+// .grid_padded--m - Left/right padding:<br>`1.1rem` tablet<br>`0` small desktop+
+// .grid_padded--l - Left/right padding:<br>`1.1rem` small desktop<br>`0` desktop+
+// .grid_padded--xl - Left/right padding:<br>`1.1rem` desktop<br>`0` large desktop+
+// .grid_padded--xxl - Left/right padding:<br>`1.1rem` large desktop<br>`0` large desktop+
 //
 // Markup: <div class="{{ className }}" style="border:2px solid black; background: #eee;"><div style="background-color: black; color: white; height: 30px">{{ className }}</div></div>
 //

--- a/assets/scss/7-layout/_grid-legacy.scss
+++ b/assets/scss/7-layout/_grid-legacy.scss
@@ -71,6 +71,17 @@
 //
 // Styleguide 7.0.1
 //
+
+
+// Section Padding (section_padded)
+//
+// Deprecated: Adds top/bottom padding for sections. Usually used with grid_padded.
+//
+//
+// Markup: <div class="section_padded" style="border:2px solid black; background: #eee;"><div style="background-color: black; color: white; height: 30px">section_padded</div></div>
+//
+// Styleguide 7.0.1
+//
 $grid-columns: 12;
 $grid-gutter: $size-b;
 $grid-gutter-px: 17.6;
@@ -396,11 +407,11 @@ $column-slug: col !default;
   margin-right: 0;
 }
 
-// .section_padded {
-//   padding-top: $size-xgiant;
-//   padding-bottom: $size-xgiant;
-//   @include mq($until: bp-m) {
-//     padding-top: $size-xl;
-//     padding-bottom: $size-xl;
-//   }
-// }
+.section_padded {
+  padding-top: $size-xxxl;
+  padding-bottom: $size-xxxl;
+  @include mq($until: bp-m) {
+    padding-top: $size-xl;
+    padding-bottom: $size-xl;
+  }
+}

--- a/assets/scss/7-layout/_grid-legacy.scss
+++ b/assets/scss/7-layout/_grid-legacy.scss
@@ -36,17 +36,38 @@
 
 // Grid Padded (grid_padded)
 //
-// Deprecated: Adds varying amounts side padding. Note: Demo is best viewed in [standalone preview](/pages/layout/grid_padded/raw-preview.html). {{isHelper}}
+// Deprecated: Adds side padding at various viewport widths. Note: Demo is best viewed in [standalone preview](/pages/layout/grid_padded/raw-preview.html). {{isHelper}}
 //
-// .grid_padded--s - .275rem
-// .grid_padded--m - 1.75rem
-// .grid_padded--l - .55rem
-// .grid_padded--xl - 1.2rem
-// .grid_padded--xxl - 1.5rem
-// .grid_padded--temp - 1.5rem
+// .grid_padded - Gutter padding:<br>`.92rem` mobile<br> `1.1rem` tablet - desktop <br>`0` large desktop
+// .grid_padded--temp - Gutter padding:<br>`0` mobile - small desktop<br>`1.1rem` desktop<br>`0` large desktop
+// .grid_padded--s - Gutter padding:<br>`1.1rem` mobile<br>`0` tablet+
+// .grid_padded--m - Gutter padding:<br>`1.1rem` tablet<br>`0` small desktop+
+// .grid_padded--l - Gutter padding:<br>`1.1rem` small desktop<br>`0` desktop+
+// .grid_padded--xl - Gutter padding:<br>`1.1rem` desktop<br>`0` large desktop+
+// .grid_padded--xxl - Gutter padding:<br>`1.1rem` large desktop<br>`0` large desktop+
 //
 // Markup: <div class="{{ className }}" style="border:2px solid black; background: #eee;"><div style="background-color: black; color: white; height: 30px">{{ className }}</div></div>
 //
+//
+// Styleguide 7.0.1
+//
+
+// Hide (hide_<from | until>--<size>)
+//
+// Deprecated: Adds varying amounts side padding. Note: Demo is best viewed in [standalone preview](/pages/layout/grid_padded/raw-preview.html). {{isHelper}}
+//
+// .hide_from--s - Hide from large mobile onward; Show small mobile only
+// .hide_from--m - Hide from tablet onward; Show on all mobile
+// .hide_from--l - Hide from small desktop onward; Show on all mobile and tablet
+// .hide_from--xl - Hide from desktop onward; Show on all mobile, tablet, and small desktop
+// .hide_from--xxl - Hide from large desktop onward; Show on all mobile, tablet, small desktop, and desktop
+// .hide_until--s - Hide until large mobile; Show on large mobile, tablet, desktop
+// .hide_until--m - Hide until tablet; Show tablet, desktop
+// .hide_until--l - Hide until small desktop; Show all desktop
+// .hide_until--xl - Hide until desktop; Show desktop, large desktop
+// .hide_until--xxl - Hide until large desktop; Show on large desktop only
+//
+// Markup: <div style="background:#ffc200;" class="{{ className }}"><strong>{{ className }}</strong>: Resize to see me appear/disappear</div>
 //
 // Styleguide 7.0.1
 //

--- a/assets/scss/7-layout/_grid-legacy.scss
+++ b/assets/scss/7-layout/_grid-legacy.scss
@@ -9,7 +9,7 @@
 // grid_container--xl - 1080px
 // grid_container--xxl - 1300px
 //
-// Markup: <div class="{{className}}">Container</div>
+// Markup: <div style="border: 2px solid black; padding: 20px;" class="{{ className }} container-demo"><strong>{{ className }}</strong> (<span></span>)</div>
 //
 // Styleguide 7.0.1
 //
@@ -28,6 +28,24 @@
 // .grid_separator--xxxl - 3rem
 //
 // Markup: <ul><li class="{{ className }}" style="border:2px solid black;">Example</li><li style="border:2px solid black;">Example</li></ul>
+//
+//
+// Styleguide 7.0.1
+//
+
+
+// Grid Padded (grid_padded)
+//
+// Deprecated: Adds varying amounts side padding. Note: Demo is best viewed in [standalone preview](/pages/layout/grid_padded/raw-preview.html). {{isHelper}}
+//
+// .grid_padded--s - .275rem
+// .grid_padded--m - 1.75rem
+// .grid_padded--l - .55rem
+// .grid_padded--xl - 1.2rem
+// .grid_padded--xxl - 1.5rem
+// .grid_padded--temp - 1.5rem
+//
+// Markup: <div class="{{ className }}" style="border:2px solid black; background: #eee;"><div style="background-color: black; color: white; height: 30px">{{ className }}</div></div>
 //
 //
 // Styleguide 7.0.1

--- a/assets/scss/7-layout/_grid.scss
+++ b/assets/scss/7-layout/_grid.scss
@@ -7,6 +7,8 @@
 // grid_container => [**l-container**](#container-l-container) <br>
 // grid_padded => [**has-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
 // grid_padded--temp => [**has-temp-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
+// col_adunit300x250 => Removed <br>
+// hide_from--{size}/hide_until--{size} => [**is-hidden-from-{size}/is-hidden-until-{size}**](pages/utilities/index.html#hidden-is-hidden-specifier)
 //
 // Markup: 7-layout/grid.html
 //

--- a/assets/scss/7-layout/_grid.scss
+++ b/assets/scss/7-layout/_grid.scss
@@ -6,6 +6,7 @@
 // grid_separator => [**has-{size}-btm-marg**](/pages/utilities/index.html#margin-has-size-btm-marg) <br>
 // grid_container => [**l-container**](#container-l-container) <br>
 // grid_padded => [**has-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
+// section_padded => [**has-section-padding**](/pages/utilities/index.html#padding-has-padding) <br>
 // grid_padded--temp => [**has-temp-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
 // col_adunit300x250 => Removed <br>
 // hide_from--{size}/hide_until--{size} => [**is-hidden-from-{size}/is-hidden-until-{size}**](pages/utilities/index.html#hidden-is-hidden-specifier)

--- a/assets/scss/7-layout/_grid.scss
+++ b/assets/scss/7-layout/_grid.scss
@@ -2,9 +2,11 @@
 //
 // This is a flexbox based grid. In the future, we'll start to rely more on CSS grid and slowly phase out this grid, piece by piece.
 //
-// _Replacements so far:_
-// grid_separator => **has-<size>-btm-marg** |
-// grid_container => **l-container**
+// _Replacements so far:_<br>
+// grid_separator => [**has-{size}-btm-marg**](/pages/utilities/index.html#margin-has-size-btm-marg) <br>
+// grid_container => [**l-container**](#container-l-container) <br>
+// grid_padded => [**has-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
+// grid_padded--temp => [**has-temp-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
 //
 // Markup: 7-layout/grid.html
 //
@@ -77,11 +79,6 @@ $column-slug: col !default;
   }
 }
 
-.col_adunit300x250 {
-  @extend %flex-col;
-  margin-right: 0;
-  max-width: 310px;
-}
 
 .grid {
   display: flex;
@@ -94,29 +91,6 @@ $column-slug: col !default;
     flex-wrap: nowrap;
   }
 
-  // .grid_padded -- DEFAULT
-  // adds left/right padding on small screens
-  &_padded {
-    padding: 0 $size-xs;
-
-    @include mq($from: bp-m, $until: bp-xl) {
-      padding: 0 $size-b;
-    }
-
-    @include mq($from: bp-xl) {
-      padding: 0;
-    }
-  }
-
-  // Custom setting for story page lead art
-  // adds left/right padding on middle-size screens
-  &_padded--temp {
-    padding: 0;
-
-    @include mq($from: bp-l, $until: bp-xl) {
-      padding: 0 $size-b;
-    }
-  }
 
   &_order {
     &--primary {
@@ -189,7 +163,7 @@ $column-slug: col !default;
 
   /**
     Use the following two classes in tandem,
-    probably with .col and .col_adunit300x250
+    probably with .col and .col_300x250
     together in a row. It flips the order
     at different breakpoints, which can be
     useful when stacking.
@@ -238,50 +212,6 @@ $column-slug: col !default;
             max-width: 100%;
           }
         }
-      }
-    }
-
-    .col_adunit300x250 {
-      flex: 0 1 100%;
-      margin-right: 0;
-      max-width: 100%;
-
-      @include mq($from: $bp) {
-        margin-left: 0;
-        margin-right: 0;
-        max-width: 310px;
-      }
-    }
-  }
-
-  // Set left/right padded until a breakpoint
-  // grid_padded--m = 1.1rem padding until bp-m
-  .grid_padded--#{$size} {
-    @include mq($until: $bp-xs) {
-      padding: 0 $size-xs;
-    }
-
-    @include mq($until: $bp) {
-      padding: 0 $size-b;
-    }
-  }
-
-  // Hide element screens > $bp
-  // i.e. display until $bp
-  .hide_from {
-    &--#{$size} {
-      @include mq($from: $bp) {
-        display: none !important;
-      }
-    }
-  }
-
-  // Hide element screens < $bp
-  // i.e. display from $bp
-  .hide_until {
-    &--#{$size} {
-      @include mq($until: $bp) {
-        display: none !important;
       }
     }
   }

--- a/assets/scss/7-layout/_grid.scss
+++ b/assets/scss/7-layout/_grid.scss
@@ -5,9 +5,9 @@
 // _Replacements so far:_<br>
 // grid_separator => [**has-{size}-btm-marg**](/pages/utilities/index.html#margin-has-size-btm-marg) <br>
 // grid_container => [**l-container**](#container-l-container) <br>
-// grid_padded => [**has-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
+// grid_padded => [**has-page-padding**](/pages/utilities/index.html#padding-has-padding) <br>
 // section_padded => [**has-section-padding**](/pages/utilities/index.html#padding-has-padding) <br>
-// grid_padded--temp => [**has-temp-gutter-padding**](/pages/utilities/index.html#padding-has-padding) <br>
+// grid_padded--temp => [**has-page-padding-at-bp-l**](/pages/utilities/index.html#padding-has-padding) <br>
 // col_adunit300x250 => Removed <br>
 // hide_from--{size}/hide_until--{size} => [**is-hidden-from-{size}/is-hidden-until-{size}**](pages/utilities/index.html#hidden-is-hidden-specifier)
 //

--- a/assets/scss/utilities/_hidden.scss
+++ b/assets/scss/utilities/_hidden.scss
@@ -20,7 +20,7 @@
 // .is-hidden-until-bp-default -  Hide until bp-default
 // .is-transparent -  Removes opacity. (Use this to fade elements out.)
 //
-// Markup: <div style="background:#ffc200;" class="{{ className }}">Resize to see me appear/disappear</div>
+// Markup: <div style="background:#ffc200;" class="{{ className }}"><strong>{{ className }}</strong>: Resize to see me appear/disappear</div>
 //
 //
 // Styleguide 8.0.1

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -35,9 +35,8 @@
 // .has-padding -  All-around padding with $size-b
 // .has-xs-padding - All-around padding with $size-xs
 // .has-xl-padding - All-around padding with $size-xl
-// .has-reset-padding - Removes padding
-// .has-gutter-padding - Left/right padding on small screens
-// .has-temp-gutter-padding - Custom setting for story page lead art
+// .has-page-padding - Left/right padding on small screens
+// .has-page-padding-at-bp-l - Custom setting for story page lead art
 // .has-section-padding - Top/bottom responsive padding
 //
 // Markup: <div style="border: 2px solid #000; background: #eee" class="{{ className }}"><div style="background: #000;color: #fff;">{{ className }}</div></div>
@@ -61,7 +60,7 @@
   padding: 0;
 }
 
-.has-gutter-padding {
+.has-page-padding {
   padding: 0 $size-xs;
   @include mq($from: bp-m, $until: bp-xl) {
     padding: 0 $size-b;
@@ -71,7 +70,7 @@
   }
 }
 
-.has-temp-gutter-padding {
+.has-page-padding-at-bp-l {
   @include mq($from: bp-l, $until: bp-xl) {
     padding: 0 $size-b;
   }

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -38,6 +38,7 @@
 // .has-reset-padding - Removes padding
 // .has-gutter-padding - Left/right padding on small screens
 // .has-temp-gutter-padding - Custom setting for story page lead art
+// .has-section-padding - Top/bottom responsive padding
 //
 // Markup: <div style="border: 2px solid #000; background: #eee" class="{{ className }}"><div style="background: #000;color: #fff;">{{ className }}</div></div>
 //
@@ -73,5 +74,14 @@
 .has-temp-gutter-padding {
   @include mq($from: bp-l, $until: bp-xl) {
     padding: 0 $size-b;
+  }
+}
+
+.has-section-padding {
+  padding-top: $size-xxxl;
+  padding-bottom: $size-xxxl;
+  @include mq($until: bp-m) {
+    padding-top: $size-xl;
+    padding-bottom: $size-xl;
   }
 }

--- a/assets/scss/utilities/_spacing.scss
+++ b/assets/scss/utilities/_spacing.scss
@@ -33,11 +33,13 @@
 // Not all sizes are accounted for. Often, specific padding rules should go on a component. {{isHelper}}
 //
 // .has-padding -  All-around padding with $size-b
-// .has-xs-padding -  All-around padding with $size-xs
-// .has-xl-padding -  All-around padding with $size-xl
-// .has-reset-padding -  Removes padding
+// .has-xs-padding - All-around padding with $size-xs
+// .has-xl-padding - All-around padding with $size-xl
+// .has-reset-padding - Removes padding
+// .has-gutter-padding - Left/right padding on small screens
+// .has-temp-gutter-padding - Custom setting for story page lead art
 //
-// Markup: <div style="background:#ffc200;" class="{{ className }}">Example</div>
+// Markup: <div style="border: 2px solid #000; background: #eee" class="{{ className }}"><div style="background: #000;color: #fff;">{{ className }}</div></div>
 //
 //
 // Styleguide 8.0.1
@@ -56,4 +58,20 @@
 
 .has-reset-padding {
   padding: 0;
+}
+
+.has-gutter-padding {
+  padding: 0 $size-xs;
+  @include mq($from: bp-m, $until: bp-xl) {
+    padding: 0 $size-b;
+  }
+  @include mq($from: bp-xl) {
+    padding: 0
+  }
+}
+
+.has-temp-gutter-padding {
+  @include mq($from: bp-l, $until: bp-xl) {
+    padding: 0 $size-b;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "2.0.0-0",
+  "version": "2.0.0-1",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "2.0.0-1",
+  "version": "2.0.0-2",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "1.2.0-1",
+  "version": "2.0.0-0",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",


### PR DESCRIPTION
#### What's this PR do?
A step toward grid cleanup

##### Classes added (if any)
- has-gutter-padding
- has-temp-gutter-padding
- has-section-padding

##### Classes removed (if any)
- grid_padded
- grid_padded--temp 
- grid_padded--{size} (5)
- hide_{from || until}--{size} (10)


#### Why are we doing this? How does it help us?
Reduction in CSS (a whole 1.73kb, but still ¯\_(ツ)_/¯ ) :
- Trims down logic for adding gutter padding at various breakpoints. We seldom use grid_padded--{size} and those have a [superfluous media query](https://github.com/texastribune/queso-ui/blob/master/assets/scss/7-layout/_grid-legacy.scss#L326-L328). 
- Removes the dynamic hide helpers, which we've already replaced thanks to @AndrewGibson27.
- Removes sidebar column. This has no replacement yet, but we'll tackle that when it comes up during homepage CSS refactor.


#### How should this be manually tested?
`yarn dev`

1. See: [has-padding](http://localhost:3000/pages/utilities/has-padding/raw-preview.html)
Resize the browser to see the gutter padding growing/shrinking

2. Bonus _new and improved legacy docs/demos_ (for no good reason, other than comparison):
     - [grid_container](http://localhost:3000/pages/layout/grid_container/raw-preview.html)
     - Scroll to grid_padded: See new descriptions of padding rules + [grid_padded demo](http://localhost:3000/pages/layout/grid_padded/raw-preview.html)
     - Scroll to hide: See new descriptions

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

It does. We rely on the hide classes in our queso-only pages in the header/footer. We also rely on grid_padded. [This PR will remedy that.](https://github.com/texastribune/texastribune/pull/3605)


#### TODOs / next steps:

* [ ] *Remove pre-release label associated with this and add 2.0.0 to tt repo*
