### PR TITLE
Add some form components

### DIFF
--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -14,6 +14,7 @@
 @import 'info-list/info-list';
 @import 'list/list';
 @import 'loading/loading';
+@import 'mini-form/mini-form';
 @import 'navbar/navbar';
 @import 'share/share';
 @import 'site-footer/site-footer';

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -8,6 +8,7 @@
 @import 'button/button';
 @import 'card/card';
 @import 'caption/caption';
+@import 'checkbox/checkbox';
 @import 'full-page-loader/full-page-loader';
 @import 'icon/icon';
 @import 'info-drop/info-drop';

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -21,3 +21,4 @@
 @import 'story-body/story-body';
 @import 'table/table';
 @import 'tabs/tabs';
+@import 'text-input/text-input';

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -25,8 +25,8 @@
   transition: opacity 0.3s;
 
   &:disabled,
-  &[disabled="true"],
-  &[disabled="disabled"] {
+  &[disabled]
+  &:not([disabled="false"]) {
     opacity: .4;
   }
 

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -24,6 +24,12 @@
   text-transform: uppercase;
   transition: opacity 0.3s;
 
+  &:disabled,
+  &[disabled="true"],
+  &[disabled="disabled"] {
+    opacity: .4;
+  }
+
   @media (hover: hover) {
     &:hover,
     &:active {

--- a/assets/scss/6-components/checkbox/_checkbox.scss
+++ b/assets/scss/6-components/checkbox/_checkbox.scss
@@ -1,0 +1,16 @@
+// Checkbox (c-checkbox)
+//
+// A good old-fashioned checkbox with light styling for alignment.
+//
+// Markup: 6-components/checkbox/checkbox.html
+//
+// Styleguide 6.1.5
+.c-checkbox {
+  line-height: $line-height-b;
+
+  input {
+    margin-bottom: 2px;
+    margin-right: 2px;
+    vertical-align: middle;
+  }
+}

--- a/assets/scss/6-components/checkbox/_checkbox.scss
+++ b/assets/scss/6-components/checkbox/_checkbox.scss
@@ -6,11 +6,20 @@
 //
 // Styleguide 6.1.5
 .c-checkbox {
-  line-height: $line-height-b;
+  display: grid;
+  gap: $size-b;
+  grid-gap: $size-b;
+  grid-template-columns: .2rem 1fr;
+  
+  &__box {
+    grid-column: 1;
+    
+    input {
+      margin-top: 4px;
+    }
+  }
 
-  input {
-    margin-bottom: 2px;
-    margin-right: 2px;
-    vertical-align: middle;
+  &__label {
+    grid-column: 2;
   }
 }

--- a/assets/scss/6-components/checkbox/checkbox.html
+++ b/assets/scss/6-components/checkbox/checkbox.html
@@ -1,4 +1,4 @@
-<div for="field-name" class="c-checkbox">
+<div class="c-checkbox">
   <div class="c-checkbox__box">
     <input id="field-name" type="checkbox">
   </div>

--- a/assets/scss/6-components/checkbox/checkbox.html
+++ b/assets/scss/6-components/checkbox/checkbox.html
@@ -1,10 +1,10 @@
 <div class="c-checkbox">
   <div class="c-checkbox__box">
-    <input id="field-name" type="checkbox">
+    <input id="color-choice-1" type="checkbox" name="color-choice" value="red">
   </div>
   <div class="c-checkbox__label">
-    <label for="field-name" class="t-size-s t-space-base has-text-gray-dark">
-      Yes, I would like to receive emails with special promotions, product announcements and membership opportunities.
+    <label for="color-choice-1" class="t-size-s t-space-base has-text-gray-dark">
+      I'd like to select the color <span style="color: red">red</span>
     </label>
   </div>
 </div>

--- a/assets/scss/6-components/checkbox/checkbox.html
+++ b/assets/scss/6-components/checkbox/checkbox.html
@@ -1,0 +1,4 @@
+<label for="field-name" class="c-checkbox t-size-s has-text-gray-dark l-display-block">
+  <input id="field-name" type="checkbox">
+  Yes, I would like to receive emails with special promotions, product announcements and membership opportunities.
+</label>

--- a/assets/scss/6-components/checkbox/checkbox.html
+++ b/assets/scss/6-components/checkbox/checkbox.html
@@ -1,4 +1,10 @@
-<label for="field-name" class="c-checkbox t-size-s has-text-gray-dark l-display-block">
-  <input id="field-name" type="checkbox">
-  Yes, I would like to receive emails with special promotions, product announcements and membership opportunities.
-</label>
+<div for="field-name" class="c-checkbox">
+  <div class="c-checkbox__box">
+    <input id="field-name" type="checkbox">
+  </div>
+  <div class="c-checkbox__label">
+    <label for="field-name" class="t-size-s t-space-base has-text-gray-dark">
+      Yes, I would like to receive emails with special promotions, product announcements and membership opportunities.
+    </label>
+  </div>
+</div>

--- a/assets/scss/6-components/mini-form/_mini-form.scss
+++ b/assets/scss/6-components/mini-form/_mini-form.scss
@@ -1,0 +1,24 @@
+// Mini form (c-mini-form)
+//
+// A text input adjacent to a button/submit input.
+//
+// Markup: 6-components/mini-form/mini-form.html
+//
+// Styleguide 6.1.5
+.c-mini-form {
+  display: grid;
+  grid-template-columns: 1fr 6rem;
+
+  &__input {
+    grid-column: 1;
+  }
+
+  &__submit {
+    grid-column: 2;
+  }
+
+  .c-text-input,
+  .c-button {
+    height: 45px;
+  }
+}

--- a/assets/scss/6-components/mini-form/mini-form.html
+++ b/assets/scss/6-components/mini-form/mini-form.html
@@ -1,0 +1,16 @@
+<form class="c-mini-form">
+  <div class="c-mini-form__input">
+    <input id="email" name="email" aria-label="email address to link" type="text" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg">
+    <ul>
+      <li class="has-text-error has-xxxs-btm-marg t-size-xs">
+        First validation error
+      </li>
+      <li class="has-text-error t-size-xs">
+        Second validation error
+      </li>
+    </ul>
+  </div>
+  <div class="c-mini-form__submit">
+    <input type="submit" disabled class="c-button c-button--s has-text-white has-bg-teal l-width-full l-display-block" value="Submit">
+  </div>
+</form>

--- a/assets/scss/6-components/text-input/_text-input.scss
+++ b/assets/scss/6-components/text-input/_text-input.scss
@@ -11,10 +11,19 @@
   border-radius: 0;
   border-style: solid;
   border-width: 1px;
-  line-height: $line-height-b;
+  outline: none;
   padding: $size-xxs;
+  transition: box-shadow .15s ease-in-out;
+
+  &:focus {
+    box-shadow: 0 0 0 .2rem rgba($color-blue-light, .4);
+  }
 
   &.is-invalid {
     border-color: $color-error;
+
+    &:focus {
+      box-shadow: 0 0 0 .2rem rgba($color-error, .4);
+    }
   }
 }

--- a/assets/scss/6-components/text-input/_text-input.scss
+++ b/assets/scss/6-components/text-input/_text-input.scss
@@ -1,0 +1,20 @@
+// Text input (c-text-input)
+//
+// Text form inputs. Can be used with type="text", type="email", etc. Add .is-valid if the value is not valid.
+//
+// Markup: 6-components/text-input/text-input.html
+//
+// Styleguide 6.1.5
+.c-text-input {
+  -webkit-appearance: none;
+  border-color: $color-gray-light;
+  border-radius: 0;
+  border-style: solid;
+  border-width: 1px;
+  line-height: $line-height-b;
+  padding: $size-xxs;
+
+  &.is-invalid {
+    border-color: $color-error;
+  }
+}

--- a/assets/scss/6-components/text-input/text-input.html
+++ b/assets/scss/6-components/text-input/text-input.html
@@ -3,7 +3,7 @@
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>
-  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark">
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark t-space-base">
 </div>
 
 <div>
@@ -11,7 +11,7 @@
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>
-  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg" aria-invalid="true">
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg t-space-base" aria-invalid="true">
   <ul>
     <li class="has-text-error has-xxxs-btm-marg t-size-xs">
       First validation error

--- a/assets/scss/6-components/text-input/text-input.html
+++ b/assets/scss/6-components/text-input/text-input.html
@@ -1,0 +1,14 @@
+<div>
+  <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
+    <strong>First name</strong>
+  </label>
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark is-invalid has-xxxs-btm-marg" aria-invalid="true">
+  <ul>
+    <li class="has-text-error has-xxxs-btm-marg t-size-xs">
+      First validation error
+    </li>
+    <li class="has-text-error t-size-xs">
+      Second validation error
+    </li>
+  </ul>
+</div>

--- a/assets/scss/6-components/text-input/text-input.html
+++ b/assets/scss/6-components/text-input/text-input.html
@@ -1,4 +1,13 @@
+<div class="has-b-btm-marg">
+  <h3 class="has-s-btm-marg">Valid state example</h3>
+  <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
+    <strong>First name</strong>
+  </label>
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark">
+</div>
+
 <div>
+  <h3 class="has-s-btm-marg">Invalid state example</h3>
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>

--- a/assets/scss/6-components/text-input/text-input.html
+++ b/assets/scss/6-components/text-input/text-input.html
@@ -2,7 +2,7 @@
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>
-  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark is-invalid has-xxxs-btm-marg" aria-invalid="true">
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg" aria-invalid="true">
   <ul>
     <li class="has-text-error has-xxxs-btm-marg t-size-xs">
       First validation error

--- a/docs/config/tasks/docs.js
+++ b/docs/config/tasks/docs.js
@@ -13,7 +13,7 @@ const htmlRunner = require('./html');
 
 const { docsStyles, docsIcons, mappedGithubData } = require('../paths.js');
 
-const COMPONENT_CSS_FILE = 'no-resets.css';
+const COMPONENT_CSS_FILE = 'all.css';
 const LEGACY_CSS_FILE = 'all-legacy.css';
 const COMPONENT_CSS_PATH = './docs/dist/css';
 


### PR DESCRIPTION
#### What's this PR do?
+ Adds components for text inputs, checkboxes, mini-form
+ Adds reduced opacity to all buttons in disabled state

##### Classes added (if any)
- `.c-text-input`
- `.c-checkbox`
- `.c-mini-form`

#### Why are we doing this? How does it help us?
These are needed for UMP, but they'll come in handy in many other places as well.

#### How should this be manually tested?
+ `yarn dev`
+ http://localhost:3000/pages/components/index.html#checkbox-c-checkbox
+ http://localhost:3000/pages/components/index.html#mini-form-c-mini-form
+ http://localhost:3000/pages/components/index.html#text-input-c-text-input

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
Nothing breaking. Will create pre-release on master once this is merged.