### PR TITLE
Success color and disabled-button fix

### DIFF
--- a/assets/scss/1-settings/_colors.scss
+++ b/assets/scss/1-settings/_colors.scss
@@ -62,6 +62,7 @@ $color-twitter: #55acee;
 // Colors:
 // $color-link-underline: $color-blue-light - Link Underline
 // $color-error: #f51c1c - Error
+// $color-success: #11A06B - Success
 // $color-fmd-blue-dark: #323a44 - Fall membership drive 1
 // $color-fmd-blue-light: #6c99c1 - Fall membership drive 2
 // $color-sponsor: #3366cc - Sponsored content signifier
@@ -70,6 +71,7 @@ $color-twitter: #55acee;
 //
 $color-link-underline: $color-blue-light;
 $color-error: #f51c1c;
+$color-success: #11A06B;
 $color-fmd-blue-dark: #323a44;
 $color-fmd-blue-light: #6c99c1;
 $color-sponsor: #3366cc;

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -28,6 +28,7 @@
   &:disabled,
   &[disabled]
   &:not([disabled="false"]) {
+    cursor: initial;
     opacity: 0.4;
 
     &:hover,


### PR DESCRIPTION
#### What's this PR do?
+ Adds `$color-success` (approved by Emily A.)
+ Makes it so disabled buttons do not have `cursor: pointer`

#### Why are we doing this? How does it help us?
A success color feels like something we'll need in more places than just UMP. And I like having the default cursor on disabled buttons because it's a further indication you can't click it.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
I'll create v2.4.0.