### PR TITLE
Fix back-2-top on Safari; remove hanging spreaker widget; add color docs

### DIFF
--- a/assets/scss/6-components/back-to-top/_back-to-top.scss
+++ b/assets/scss/6-components/back-to-top/_back-to-top.scss
@@ -1,6 +1,6 @@
 // Back to top (c-back-to-top)
 //
-// This is a weird one because it is opinionated on position. It could also be converted to a more global style, but for now we're keeping it specific to this one use. This also depends on a JS helper. NOTE: The trick is to place this class outside of your button since position: sticky works best on direct children of a body tag.
+// This component is is opinionated on position. There is an optional `c-back-to-top-viewport` class, which is used to conditionally show back-to-top when the viewport is scrolled for a bit. That feature requires some [extra JS](https://github.com/texastribune/texastribune/blob/master/snollygoster/common/js/modules/entry-utils/ui/index.js#L18-L34). <h4>Note:</h4><ol><li>Place this class outside of your back to top button because `position: sticky` works best on direct children of body.</li><li>To use `position: sticky` on Safari, you need a block-level element.</li></ol>
 //
 //
 // Markup: 6-components/back-to-top/back-to-top.html
@@ -11,8 +11,16 @@
   left: 100%;
   opacity: 1;
   padding-right: $size-s;
+  pointer-events: none;
   position: sticky;
   transition: opacity .3s;
+  // Safari won't allow inline-block; we need a width for positioning.
+  // If this grows in the future, consider making this a variation.
+  width: 4rem;
+
+  &__inner {
+    pointer-events: all;
+  }
 }
 
 

--- a/assets/scss/6-components/back-to-top/back-to-top.html
+++ b/assets/scss/6-components/back-to-top/back-to-top.html
@@ -1,7 +1,22 @@
-<div class="c-back-to-top l-display-ib">
-  <button class="c-button c-button--circle">
-    <span class="l-align-center-y t-size-xxs"><span class="c-icon c-icon--arrow-up l-display-block"><svg aria-hidden="true">
-        <use xlink:href="#arrow-up"></use>
-    </svg></span>Back to Top</span>
+<div>Lorem ipsum dolor, sit amet consectetur adipisicing elit. Ipsa, magni ad, quae iste quos dicta fuga, harum aliquam expedita accusantium voluptatum illo quis! Neque ea dolore veritatis corporis, ab temporibus! Lorem ipsum dolor sit amet consectetur adipisicing elit. Sed, eius aut. Ducimus qui recusandae laborum voluptatem alias nemo dicta. Porro aspernatur, dolorem doloribus repellat repellendus odit perspiciatis! Facere, fuga atque. Lorem ipsum dolor sit amet consectetur adipisicing elit. Vero inventore dicta quo ipsam deserunt assumenda expedita qui deleniti, saepe sed eligendi harum error quas dolores aspernatur quos autem tenetur dolore. Lorem ipsum dolor sit amet consectetur adipisicing elit. Autem sit, architecto veritatis sapiente, mollitia aspernatur voluptas odit modi, cupiditate illum quam ipsum porro quasi omnis error saepe laborum expedita aliquam! Lorem ipsum, dolor sit amet consectetur adipisicing elit. Minus laboriosam veritatis dolorem quis similique repudiandae ipsam. A perspiciatis unde tenetur est delectus in repudiandae dolor quibusdam, dolore nobis, iusto cupiditate. Lorem ipsum dolor sit amet consectetur adipisicing elit. Porro assumenda, quis quibusdam sequi iste voluptatibus accusamus accusantium sint id similique facere. Doloremque, assumenda temporibus repellendus nulla labore quod recusandae quos. Lorem ipsum dolor sit, amet consectetur adipisicing elit. Quidem, vero amet. Obcaecati unde ipsum iste odio recusandae eaque fugiat dolor beatae! Nam placeat, sequi cumque itaque voluptatem dolores quam ea. Lorem ipsum, dolor sit amet consectetur adipisicing elit. Soluta debitis fugit quasi quidem repellendus natus ea qui voluptates, placeat saepe cupiditate enim. Earum nostrum neque vero at. Neque, consequuntur. Nesciunt. Lorem ipsum dolor sit amet consectetur adipisicing elit. Autem repudiandae tempore voluptatum ex pariatur omnis illo ullam consequuntur eveniet quisquam quidem temporibus quas similique error a architecto laboriosam, voluptatibus fuga. Lorem ipsum dolor sit amet consectetur adipisicing elit. Illum nisi mollitia minus molestias incidunt assumenda quo vitae velit quod veritatis expedita veniam ipsum saepe beatae, et consequatur pariatur quisquam impedit.</div>
+<div id="back-to-top-btn" class="c-back-to-top">
+  <button class="c-back-to-top__inner c-button c-button--circle">
+    <span class="l-align-center-y t-size-xxs">
+      <span class="c-icon c-icon--arrow-up l-display-block">
+        <svg aria-hidden="true">
+          <use xlink:href="#arrow-up"></use>
+        </svg>
+      </span>Back to Top</span>
   </button>
 </div>
+
+<script>
+const BUTTON = '#back-to-top-btn';
+document.querySelector(BUTTON).addEventListener('click', () => {
+  window.scrollTo({
+    behavior: 'smooth',
+    left: 0,
+    top: 0,
+  });
+});
+</script>

--- a/assets/scss/6-components/card/_card.scss
+++ b/assets/scss/6-components/card/_card.scss
@@ -1,6 +1,6 @@
 // Card (c-card)
 //
-// Generic card used for articles, podcasts, events, and more! {{isWide}}
+// Generic card used for articles, podcasts, events, and more. Todo: Remove grid classes and replace with CSS grid. {{isWide}}
 //
 //
 // Markup: 6-components/card/card.html

--- a/assets/scss/6-components/card/card.html
+++ b/assets/scss/6-components/card/card.html
@@ -18,8 +18,8 @@
       </a>
       <div class="hide_until--l">
         <cite class="has-test-gray-dark t-size-xxxs"
-          ><span class="c-icon"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span>
-          Miguel Gutierrez Jr./The Texas Tribune
+          ><span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span>
+          Lorem Picsum
         </cite>
       </div>
     </figure>
@@ -29,13 +29,12 @@
       <h3 class="t-headline c-card__title">
         <a
           href="#"
-          >In special election runoff for Texas House seat, Democrats work to
-          avoid repeat of 2018 upset</a
+          >The headline of this article is Headline 1234. Lorem ipsum dolor sit amet consectetur adipisicing elit.</a
         >
       </h3>
       <p class="t-byline has-text-gray t-linkstyle t-size-xxs">
         <span class="t-byline__item"
-          >by <a href="/about/staff/patrick-svitek/">Patrick Svitek</a></span
+          >by <a href="#">Author Name</a></span
         >
         <time
           class="t-byline__item"
@@ -47,9 +46,7 @@
     </header>
     <div class="t-prose c-card__desc hide_until--s t-size-s">
       <p class="l-display-inline">
-        Tuesday's special election runoff for House District 125 is drawing many
-        comparisons to the state Senate race that Democrats lost last year — but
-        this time, the party isn't leaving anything up to chance.
+        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Dolorum tenetur officiis voluptates, sequi temporibus nobis, fugit blanditiis facere totam doloribus deleniti minus reiciendis. Repellat at tempora quo commodi, quaerat aut!
       </p>
       <span class="t-linkstyle t-uppercase"
         ><a
@@ -85,7 +82,7 @@
       <div class="hide_until--l">
         <cite class="has-test-gray-dark t-size-xxxs"
           ><span class="c-icon"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span>
-          Miguel Gutierrez Jr./The Texas Tribune
+          Lorem Picsum
         </cite>
       </div>
     </figure>
@@ -95,13 +92,12 @@
       <h1 class="t-headline c-card__title c-card__title--lg">
         <a
           href="#"
-          >In special election runoff for Texas House seat, Democrats work to
-          avoid repeat of 2018 upset</a
+          >The headline of this article is Headline 1234. Lorem ipsum dolor sit amet consectetur adipisicing elit.</a
         >
       </h1>
       <p class="t-byline has-text-gray t-linkstyle t-size-xxs">
         <span class="t-byline__item"
-          >by <a href="/about/staff/patrick-svitek/">Patrick Svitek</a></span
+          >by <a href="#">Author Name</a></span
         >
         <time
           class="t-byline__item"
@@ -113,9 +109,7 @@
     </header>
     <section class="t-prose c-card__desc grid_separator t-size-s">
       <p class="l-display-inline">
-        Tuesday's special election runoff for House District 125 is drawing many
-        comparisons to the state Senate race that Democrats lost last year — but
-        this time, the party isn't leaving anything up to chance.
+        Lorem ipsum dolor, sit amet consectetur adipisicing elit. Maxime sit consequatur commodi at, tempora dignissimos recusandae alias, ipsum debitis nostrum, porro exercitationem iusto quaerat? Aperiam illo harum reiciendis quia tempora?
       </p>
       <span class="t-linkstyle t-uppercase"
         ><a
@@ -134,9 +128,8 @@
         <li>
           <a
             class="t-unlink t-serif"
-            href="/2019/02/28/texas-senate-committee-sick-leave-ordinance-austin-san-antonio/"
-            >Texas Senate panel advances bill banning cities from adopting sick
-            leave ordinances</a
+            href="#"
+            >The headline for a related article would be displayed here.</a
           >
         </li>
       </ul>
@@ -169,7 +162,7 @@
     <h4 class="t-headline">
       <a
         href="https://www.texastribune.org/2019/03/09/texas-senate-beto-orourke-president-film-screening/"
-        >A “big announcement” from Beto O'Rourke is on the horizon</a
+        >The headline for an article would be displayed here</a
       >
     </h4>
   </div>
@@ -191,7 +184,7 @@
       <img class="l-display-block l-width-full" src="https://picsum.photos/800/420?random" />
     </a>
   </figure>
-  <div class="c-card__tag l-display-ib has-bg-black-off t-smallcaps">
+  <div class="c-card__tag l-display-ib has-bg-black-off t-smallcaps t-align-center">
     <div class="t-uppercase has-text-yellow t-size-xs">March</div>
     <div class="t-giant has-text-white t-space-nospace">14</div>
   </div>
@@ -199,7 +192,7 @@
     <div class="grid_row--from_m">
       <header class="col">
         <h2 class="t-headline c-card__overlay-text t-l">
-          A Public Education Conversation with Rep. Dan Huberty
+          Title of Event goes here
         </h2>
         <h5 class="t-smallcaps t-size-xs grid_separator--s">
           Austin | 7:30 a.m. - 9 a.m.
@@ -260,8 +253,7 @@
     </div>
     <div class="l-width-full">
       <div class="t-uppercase t-uppercase--extra-wide has-text-gray t-size-xxs grid_separator--xs">Play the latest episode</div>
-      <iframe src="https://widget.spreaker.com/player?show_id=2716012&amp;theme=light&amp;playlist=true&amp;playlist-continuous=true&amp;playlist-loop=false&amp;playlist-autoupdate=true&amp;autoplay=false&amp;live-autoplay=false&amp;chapters-image=true&amp;episode_image_position=right&amp;hide-likes=true&amp;hide-comments=false&amp;hide-sharing=false&amp;hide-logo=true&amp;hide-download=true&amp;hide-episode-description=false&amp;hide-playlist-images=false&amp;hide-playlist-descriptions=false&amp;gdpr-consent=undefined" class="spreaker-player l-display-block" id="spreaker-player-160950" width="100%" height="78px" frameborder="0"></iframe>
+      <div class="has-bg-black has-text-white l-align-center-children" style="height: 78px">Player widget</div>
     </div>
   </section>
 </article>
-<script async src="https://widget.spreaker.com/widgets.js"></script>

--- a/assets/scss/7-layout/_width.scss
+++ b/assets/scss/7-layout/_width.scss
@@ -5,7 +5,7 @@
 // .l-width-full - Width is 100% of parent
 // .l-width-max - Max-width: 100%. Never greater than parent, but not stretched beyond its natural size.
 //
-// Markup: <div style="border:2px solid black"><img class="{{ className }}" src="https://picsum.photos/250?random"/></div>
+// Markup: <div style="border:2px solid black"><img class="{{ className }}" src="https://static.texastribune.org/media/images/2015/10/22/SpaceJam_Nightscapes_BO_DSC02387.jpg"/></div>
 // 
 //
 // Styleguide 7.0.5

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -15,6 +15,9 @@
 // .has-text-blue-dark - blue dark text color
 // .has-text-error - error text color
 // .has-text-success - success text color
+// .has-text-sponsor - sponsor text color
+// .has-text-facebook - facebook text color
+// .has-text-twitter - twitter text color
 //
 // Markup: <p class="{{ className }}">Example</p>
 //
@@ -39,6 +42,9 @@
 // .has-text-hover-blue-dark - blue dark text-hover color
 // .has-text-hover-error - error text-hover color
 // .has-text-hover-success - success text-hover color
+// .has-text-hover-sponsor - sponsor text-hover color
+// .has-text-hover-facebook - facebook text-hover color
+// .has-text-hover-twitter - twitter text-hover color
 //
 // Markup: <p class="{{ className }}">Hover me</p>
 //
@@ -63,6 +69,9 @@
 // .has-bg-blue-dark - blue dark background color
 // .has-bg-error - error background color
 // .has-bg-success - success background color
+// .has-bg-sponsor - sponsor background color
+// .has-bg-facebook - facebook background color
+// .has-bg-twitter - twitter background color
 //
 // Markup: <div class="has-padding {{ className }}">Example</div>
 //

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -25,14 +25,28 @@
   padding: 1rem 0;
 }
 
-.ds-desc a {
-  text-decoration: underline;
-  font-weight: bold;
+.ds-desc {
+  a {
+    text-decoration: underline;
+    font-weight: bold;
+  }
+
+  p {
+    margin-bottom: 1rem;
+  }
+
+  ol,
+  ul {
+    margin: .5rem;
+    padding-left: 2rem;
+    font-size: medium;
+
+    li {
+      margin-bottom: .5rem;
+    }
+  }
 }
 
-.ds-desc p {
-  margin-bottom: 1rem;
-}
 
 .ds-menu {
   overflow: scroll;


### PR DESCRIPTION
#### What's this PR do?

- Addresses back-to-top bug on in Safari. (Safari does not like inline-block + position: sticky 😢 )
- Adds missing `$color-sponsor` `$color-twitter` `$color-facebook` to color helpers
- I noticed the components page display was taking forever waiting on the Spreaker width in the podcast card, so I removed it. Also I updated some of the placeholder text to be more generic.

#### Why are we doing this? How does it help us?

Gets the back to top displaying more consistently and provides for better documentation of a few components.

#### How should this be manually tested?
`yarn dev`

See: [Most of the updates happen in components](http://localhost:3000/pages/components/#back-to-top-c-back-to-top)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

No, I consider this a patch and will call it `v2.4.2`


#### TODOs / next steps:

* [ ] *Make markup updates on the back to top element on the donor wall*
