### PR TITLE
Add a content grid layout

### DIFF
--- a/assets/scss/7-layout/_all.scss
+++ b/assets/scss/7-layout/_all.scss
@@ -5,6 +5,7 @@
 // Styleguide 7.0.0
 @import 'align';
 @import 'container';
+@import 'content-grid';
 @import 'display';
 @import 'grid';
 @import 'multicol';

--- a/assets/scss/7-layout/_content-grid.scss
+++ b/assets/scss/7-layout/_content-grid.scss
@@ -1,24 +1,21 @@
 // Content Grid (l-content-grid)
 //
-// Standard two col grid with a content area and sidebar. We use CSS variables to allow for flexibility in setting column ratios, order, and gap size. This grid starts at `bp-l`. The default sidebar width is to account for 300x250 ads.
+// Standard two col grid with a content area and sidebar. This grid starts at `bp-l`. The sidebar width is to account for 300x250 ads. {{isWide}}
+//
+// .l-content-grid--reversed - Left sidebar and right content
+// .l-content-grid--flush - No grid gap
 //
 // Markup: 7-layout/content-grid.html
 //
 // Styleguide 7.0.1
 //
-:root {
-  --content-grid-order: 'content side';
-  --content-grid-template: 1fr 310px;
-  --content-grid-gap: #{$size-xxl};
-}
-
 .l-content-grid {
   @supports (display: grid) {
     @include mq($from: bp-l) {
-      @include gap(var(--content-grid-gap));
+      @include gap($size-xxl);
       display: grid;
-      grid-template-areas: var(--content-grid-order);
-      grid-template-columns: var(--content-grid-template);
+      grid-template-areas: 'content side';
+      grid-template-columns: 1fr 310px;
 
       &__side {
         grid-area: side;
@@ -26,6 +23,15 @@
 
       &__content {
         grid-area: content;
+      }
+
+      &--reversed {
+        grid-template-areas: 'side content';
+        grid-template-columns: 310px 1fr;
+      }
+      
+      &--flush {
+        @include gap(0);
       }
     }
   }

--- a/assets/scss/7-layout/_content-grid.scss
+++ b/assets/scss/7-layout/_content-grid.scss
@@ -1,6 +1,6 @@
 // Content Grid (l-content-grid)
 //
-// Standard two col grid with a content area and sidebar. We use CSS variables for ease of overriding the columns. This grid starts at `bp-l`. The default sidebar width is to account for 300x250 ads.
+// Standard two col grid with a content area and sidebar. We use CSS variables to allow for flexibility in setting column ratios, order, and gap size. This grid starts at `bp-l`. The default sidebar width is to account for 300x250 ads.
 //
 // Markup: 7-layout/content-grid.html
 //

--- a/assets/scss/7-layout/_content-grid.scss
+++ b/assets/scss/7-layout/_content-grid.scss
@@ -9,13 +9,15 @@
 //
 // Styleguide 7.0.1
 //
+$content-grid-sidebar: px-to-rem(310px);
+
 .l-content-grid {
   @supports (display: grid) {
     @include mq($from: bp-l) {
       @include gap($size-xxl);
       display: grid;
       grid-template-areas: 'content side';
-      grid-template-columns: 1fr 310px;
+      grid-template-columns: 1fr $content-grid-sidebar;
 
       &__side {
         grid-area: side;
@@ -27,7 +29,7 @@
 
       &--reversed {
         grid-template-areas: 'side content';
-        grid-template-columns: 310px 1fr;
+        grid-template-columns: $content-grid-sidebar 1fr;
       }
       
       &--flush {

--- a/assets/scss/7-layout/_content-grid.scss
+++ b/assets/scss/7-layout/_content-grid.scss
@@ -1,0 +1,32 @@
+// Content Grid (l-content-grid)
+//
+// Standard two col grid with a content area and sidebar. We use CSS variables for ease of overriding the columns. This grid starts at `bp-l`. The default sidebar width is to account for 300x250 ads.
+//
+// Markup: 7-layout/content-grid.html
+//
+// Styleguide 7.0.1
+//
+:root {
+  --content-grid-order: 'content side';
+  --content-grid-template: 1fr 310px;
+  --content-grid-gap: #{$size-xxl};
+}
+
+.l-content-grid {
+  @supports (display: grid) {
+    @include mq($from: bp-l) {
+      @include gap(var(--content-grid-gap));
+      display: grid;
+      grid-template-areas: var(--content-grid-order);
+      grid-template-columns: var(--content-grid-template);
+
+      &__side {
+        grid-area: side;
+      }
+
+      &__content {
+        grid-area: content;
+      }
+    }
+  }
+}

--- a/assets/scss/7-layout/content-grid.html
+++ b/assets/scss/7-layout/content-grid.html
@@ -1,24 +1,4 @@
-<div class="l-content-grid">
-  <div class="l-content-grid__content has-bg-white-off">
-    <h3 class="has-padding">Content</h3>
-  </div>
-  <div class="l-content-grid__side has-bg-gray-light">
-    <h3 class="has-padding">Sidebar</h3>
-  </div>
-</div>
-
-<hr>
-
-<p>Example with overrides</p>
-<style>
-/* Scope to a variation of your choosing */
-.l-content-grid--custom {
-  --content-grid-order: 'side content';
-  --content-grid-template: 20rem 1fr;
-  --content-grid-gap: 0;
-}
-</style>
-<div class="l-content-grid l-content-grid--custom">
+<div class="l-content-grid {{ className }}">
   <div class="l-content-grid__content has-bg-white-off">
     <h3 class="has-padding">Content</h3>
   </div>

--- a/assets/scss/7-layout/content-grid.html
+++ b/assets/scss/7-layout/content-grid.html
@@ -1,0 +1,28 @@
+<div class="l-content-grid">
+  <div class="l-content-grid__content has-bg-white-off">
+    <h3 class="has-padding">Content</h3>
+  </div>
+  <div class="l-content-grid__side has-bg-gray-light">
+    <h3 class="has-padding">Sidebar</h3>
+  </div>
+</div>
+
+<hr>
+
+<p>Example with overrides</p>
+<style>
+/* Scope to a variation of your choosing */
+.l-content-grid--custom {
+  --content-grid-order: 'side content';
+  --content-grid-template: 20rem 1fr;
+  --content-grid-gap: 0;
+}
+</style>
+<div class="l-content-grid l-content-grid--custom">
+  <div class="l-content-grid__content has-bg-white-off">
+    <h3 class="has-padding">Content</h3>
+  </div>
+  <div class="l-content-grid__side has-bg-gray-light">
+    <h3 class="has-padding">Sidebar</h3>
+  </div>
+</div>


### PR DESCRIPTION
#### What's this PR do?

Adds a layout class to establish a simple two column grid.

##### Classes added (if any)
- l-content-grid

#### Why are we doing this? How does it help us?

As I was reorganizing the sass files in in the custom grid I added for [The Blast](https://www.texastribune.org/theblast/), it occurred to me that it might be better served as a global component.

Some potential future implementations of this
- The homepage
- The about page
- UMP

#### How should this be manually tested?
`yarn dev`

See: [l-content-grid](http://localhost:3000/pages/layout/l-content-grid/raw-preview.html)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

No just a minor release.


#### TODOs / next steps:

* [ ] *Bring into https://github.com/texastribune/texastribune/pull/3620*
