### PR TITLE
Fix checkbox grid

### DIFF
--- a/assets/scss/6-components/checkbox/_checkbox.scss
+++ b/assets/scss/6-components/checkbox/_checkbox.scss
@@ -6,9 +6,9 @@
 //
 // Styleguide 6.1.5
 .c-checkbox {
-  @include gap;
+  @include gap($size-xxxs);
   display: grid;
-  grid-template-columns: .2rem 1fr;
+  grid-template-columns: auto 1fr;
   
   &__box {
     grid-column: 1;


### PR DESCRIPTION
#### What's this PR do?
Allows the first column of the checkbox grid to fill the space it needs. I don't know why I didn't do this to start.

#### Why are we doing this? How does it help us?
More safe across browsers. They all style checkboxes a little bit differently, so let's ensure we never have any overflow.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
Will create 2.5.1.