### PR TITLE
A few form updates

### DIFF
--- a/assets/scss/6-components/checkbox/_checkbox.scss
+++ b/assets/scss/6-components/checkbox/_checkbox.scss
@@ -6,13 +6,15 @@
 //
 // Styleguide 6.1.5
 .c-checkbox {
-  @include gap($size-xxxs);
-  display: grid;
-  grid-template-columns: auto 1fr;
+  &__inputs {
+    @include gap($size-xxxs);
+    display: grid;
+    grid-template-columns: auto 1fr;
+  }
   
   &__box {
     grid-column: 1;
-    
+
     input {
       margin-top: 4px;
     }

--- a/assets/scss/6-components/checkbox/checkbox.html
+++ b/assets/scss/6-components/checkbox/checkbox.html
@@ -1,10 +1,15 @@
-<div class="c-checkbox">
-  <div class="c-checkbox__box">
-    <input id="color-choice-1" type="checkbox" name="color-choice" value="red">
+<div class="c-checkbox t-space-base">
+  <div class="c-checkbox__inputs has-xxxs-btm-marg">
+    <div class="c-checkbox__box">
+      <input id="color-choice-1" type="checkbox" name="color-choice" value="red">
+    </div>
+    <div class="c-checkbox__label">
+      <label for="color-choice-1" class="t-size-s t-space-base has-text-gray-dark">
+        This is a fun label
+      </label>
+    </div>
   </div>
-  <div class="c-checkbox__label">
-    <label for="color-choice-1" class="t-size-s t-space-base has-text-gray-dark">
-      I'd like to select the color <span style="color: red">red</span>
-    </label>
-  </div>
+  <ul class="has-text-error t-size-xs">
+    <li>You must check this field to submit the form</li>
+  </ul>
 </div>

--- a/assets/scss/6-components/mini-form/_mini-form.scss
+++ b/assets/scss/6-components/mini-form/_mini-form.scss
@@ -17,7 +17,7 @@
     grid-column: 2;
   }
 
-  .c-text-input,
+  .c-text-input__input,
   .c-button {
     height: 45px;
   }

--- a/assets/scss/6-components/mini-form/mini-form.html
+++ b/assets/scss/6-components/mini-form/mini-form.html
@@ -1,14 +1,16 @@
 <form class="c-mini-form">
   <div class="c-mini-form__input">
-    <input id="email" name="email" aria-label="email address to link" type="text" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg">
-    <ul>
-      <li class="has-text-error has-xxxs-btm-marg t-size-xs">
-        First validation error
-      </li>
-      <li class="has-text-error t-size-xs">
-        Second validation error
-      </li>
-    </ul>
+    <div class="c-text-input">
+      <input id="email" name="email" aria-label="email address to link" type="text" class="c-text-input__input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg">
+      <ul>
+        <li class="has-text-error has-xxxs-btm-marg t-size-xs">
+          First validation error
+        </li>
+        <li class="has-text-error t-size-xs">
+          Second validation error
+        </li>
+      </ul>
+    </div>
   </div>
   <div class="c-mini-form__submit">
     <input type="submit" disabled class="c-button c-button--s has-text-white has-bg-teal l-width-full l-display-block" value="Submit">

--- a/assets/scss/6-components/text-input/_text-input.scss
+++ b/assets/scss/6-components/text-input/_text-input.scss
@@ -6,30 +6,32 @@
 //
 // Styleguide 6.1.5
 .c-text-input {
-  -webkit-appearance: none;
-  border-color: $color-gray-light;
-  border-radius: 0;
-  border-style: solid;
-  border-width: 1px;
-  outline: none;
-  padding: $size-xxs;
-  transition: box-shadow .15s ease-in-out;
+  &__input {
+    -webkit-appearance: none;
+    border-color: $color-gray-light;
+    border-radius: 0;
+    border-style: solid;
+    border-width: 1px;
+    outline: none;
+    padding: $size-xxs;
+    transition: box-shadow .15s ease-in-out;
 
-  // kill X button that appears on IE and edge
-  // because it doesn't handle JS input event correctly
-  &::-ms-clear {
-    display: none;
-  }
-
-  &:focus {
-    box-shadow: 0 0 0 .2rem rgba($color-blue-light, .4);
-  }
-
-  &.is-invalid {
-    border-color: $color-error;
+    // kill X button that appears on IE and edge
+    // because it doesn't handle JS input event correctly
+    &::-ms-clear {
+      display: none;
+    }
 
     &:focus {
-      box-shadow: 0 0 0 .2rem rgba($color-error, .4);
+      box-shadow: 0 0 0 .2rem rgba($color-blue-light, .4);
+    }
+
+    &.is-invalid {
+      border-color: $color-error;
+
+      &:focus {
+        box-shadow: 0 0 0 .2rem rgba($color-error, .4);
+      }
     }
   }
 }

--- a/assets/scss/6-components/text-input/text-input.html
+++ b/assets/scss/6-components/text-input/text-input.html
@@ -1,17 +1,17 @@
-<div class="has-b-btm-marg">
+<div class="c-text-input has-b-btm-marg">
   <h3 class="has-s-btm-marg">Valid state example</h3>
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>
-  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input l-display-block l-width-full has-text-gray-dark t-space-base">
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input__input l-display-block l-width-full has-text-gray-dark t-space-base">
 </div>
 
-<div>
+<div class="c-text-input">
   <h3 class="has-s-btm-marg">Invalid state example</h3>
   <label for="firstName" class="l-display-block has-xxxs-btm-marg t-size-s">
     <strong>First name</strong>
   </label>
-  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg t-space-base" aria-invalid="true">
+  <input id="firstName" name="firstName" type="text" value="Cosmo Kramer" class="c-text-input__input is-invalid l-display-block l-width-full has-text-gray-dark has-xxxs-btm-marg t-space-base" aria-invalid="true">
   <ul>
     <li class="has-text-error has-xxxs-btm-marg t-size-xs">
       First validation error


### PR DESCRIPTION
#### What's this PR do?
+ Make it so, instead of `c-text-input` living on the input itself, it lives on the `div` surrounding the input. This is for consistency with `c-checkbox` and, I think, makes more sense: The component isn't just the input -- it's the input, the label and any error messages.
+ Adds invalid-state functionality to `c-checkbox`

##### Classes added (if any)
- `c-text-input__input`
- `c-checkbox__inputs`

#### Why are we doing this? How does it help us?
Just figurin' out this form stuff as I go.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
This is indeed breaking! But it will only break things in UMP read/write, which isn't live yet. I'll update it.