### PR TITLE
Add first attempt at grid helper and global updates 

### DIFF
--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -55,7 +55,9 @@ hr {
   border: 1px solid $color-gray-light;
 }
 
-// By default we add leading to paragraphs
-p {
+// By default we add leading to paragraphs, lists, and captions
+p,
+ul,
+figcaption {
   line-height: $line-height-b;
 }

--- a/assets/scss/7-layout/_all.scss
+++ b/assets/scss/7-layout/_all.scss
@@ -5,6 +5,7 @@
 // Styleguide 7.0.0
 @import 'align';
 @import 'container';
+@import 'col-grid';
 @import 'content-grid';
 @import 'display';
 @import 'grid';

--- a/assets/scss/7-layout/_col-grid.scss
+++ b/assets/scss/7-layout/_col-grid.scss
@@ -1,9 +1,8 @@
 // Column grid (l-col-grid)
 //
-// Just testing the waters of a tiny grid helper. For now, used on photo grids and in AMP templates. {{isHelper}}
+// Just testing the waters of a tiny grid helper. For now, used on photo grids and in AMP templates. By default the grid is an even two column grid. We include variations for col counts and spacing.
 //
-// l-col-grid--2x - Columns split 50/50
-// l-col-grid--3x - Columns split in thirds
+// l-col-grid--1x3 - Columns split in thirds
 // l-col-grid--xxxs-gap - Shrink up the default gap. Used on photo grid
 // l-col-grid--resp - Collapse all columns at `bp-m`
 //
@@ -15,17 +14,14 @@
   @supports (display: grid) {
     @include gap;
     display: grid;
+    grid-template-columns: repeat(2, 1fr);
 
-    &--2x {
-      grid-template-columns: repeat(2, 1fr);
-    }
-
-    &--3x {
+    &--1x3 {
       grid-template-columns: repeat(3, 1fr);
     }
 
     &--xxxs-gap {
-      @include gap(.5rem);
+      @include gap($size-xxxs);
     }
     
     @include mq($until: bp-m) {

--- a/assets/scss/7-layout/_col-grid.scss
+++ b/assets/scss/7-layout/_col-grid.scss
@@ -4,7 +4,7 @@
 //
 // l-col-grid--1x3 - Columns split in thirds
 // l-col-grid--xxxs-gap - Shrink up the default gap. Used on photo grid
-// l-col-grid--resp - Collapse all columns at `bp-m`
+// l-col-grid--1x1-until-bp-m - Collapse all columns at `bp-m`
 //
 // Markup: 7-layout/col-grid.html
 //
@@ -25,7 +25,7 @@
     }
     
     @include mq($until: bp-m) {
-      &--resp {
+      &--1x1-until-bp-m {
         grid-template-columns: 1fr;
       }
     }

--- a/assets/scss/7-layout/_col-grid.scss
+++ b/assets/scss/7-layout/_col-grid.scss
@@ -1,0 +1,37 @@
+// Column grid (l-col-grid)
+//
+// Just testing the waters of a tiny grid helper. For now, used on photo grids and in AMP templates. {{isHelper}}
+//
+// l-col-grid--2x - Columns split 50/50
+// l-col-grid--3x - Columns split in thirds
+// l-col-grid--xxxs-gap - Shrink up the default gap. Used on photo grid
+// l-col-grid--resp - Collapse all columns at `bp-m`
+//
+// Markup: 7-layout/col-grid.html
+//
+// Styleguide 7.0.1
+//
+.l-col-grid {
+  @supports (display: grid) {
+    @include gap;
+    display: grid;
+
+    &--2x {
+      grid-template-columns: repeat(2, 1fr);
+    }
+
+    &--3x {
+      grid-template-columns: repeat(3, 1fr);
+    }
+
+    &--xxxs-gap {
+      @include gap(.5rem);
+    }
+    
+    @include mq($until: bp-m) {
+      &--resp {
+        grid-template-columns: 1fr;
+      }
+    }
+  }
+}

--- a/assets/scss/7-layout/col-grid.html
+++ b/assets/scss/7-layout/col-grid.html
@@ -1,11 +1,10 @@
-<div class="l-col-grid {{ className }}{% if className === 'l-col-grid--resp' or className === 'l-col-grid--xxxs-gap' %} l-col-grid--2x{% endif %}">
+<div class="l-col-grid {{ className }} t-align-center">
   <div class="has-padding has-bg-white-off">1</div>
   <div class="has-padding has-bg-white-off">2</div>
   <div class="has-padding has-bg-white-off">3</div>
   <div class="has-padding has-bg-white-off">4</div>
-  {% if className === 'l-col-grid--3x' %}
+  {% if className === 'l-col-grid--1x3' %}
     <div class="has-padding has-bg-white-off">5</div>
     <div class="has-padding has-bg-white-off">6</div>
   {% endif %}
 </div>
-

--- a/assets/scss/7-layout/col-grid.html
+++ b/assets/scss/7-layout/col-grid.html
@@ -1,0 +1,11 @@
+<div class="l-col-grid {{ className }}{% if className === 'l-col-grid--resp' or className === 'l-col-grid--xxxs-gap' %} l-col-grid--2x{% endif %}">
+  <div class="has-padding has-bg-white-off">1</div>
+  <div class="has-padding has-bg-white-off">2</div>
+  <div class="has-padding has-bg-white-off">3</div>
+  <div class="has-padding has-bg-white-off">4</div>
+  {% if className === 'l-col-grid--3x' %}
+    <div class="has-padding has-bg-white-off">5</div>
+    <div class="has-padding has-bg-white-off">6</div>
+  {% endif %}
+</div>
+

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -99,10 +99,10 @@
 }
 
 .ds-grid-lines {
-  background-size: 16px 16px;
+  background-size: 1rem 1rem;
   background-image: linear-gradient(to right, #eee 1px, transparent 1px),
     linear-gradient(to bottom, #eee 1px, transparent 1px);
-  border: 1px solid #eee;
+  padding: 1rem;
 
   .ds-hide-grid & {
     border: none;


### PR DESCRIPTION
#### What's this PR do?
Adds a grid helper more global line-heights.

##### Classes added (if any)
- l-col-grid
- l-col-grid--1x3
- l-col-grid--xxxs-gap
- l-col-grid--resp

#### Why are we doing this? How does it help us?

l-col-grid - This is essentially the photo grid styles, but a little more generalized. We [talked about](https://github.com/texastribune/texastribune/pull/3629#issuecomment-526269751) how that one is implemented in the story page style swap PR. 

All `figcaption` and `ul` tags' line-height will be our base line-height - Hopefully this adds consistency and saves us from keep having to set it with our `t-space-base` helper.

#### How should this be manually tested?
`yarn dev`

See: [`l-col-grid`](http://localhost:3000/pages/layout/index.html#column-grid-l-col-grid)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

The footer links on queso templates will get a little more spaced out with the line-height, but that feels too trivial to me to deem it "_breaking_." I'd be more inclined to call this a minor release.


#### TODOs / next steps:

* [ ] *Add this to the /texastribune story page updates (I feel fine for this to wait until after initial deploy since there's so many moving parts in https://github.com/texastribune/texastribune/pull/3629)*
