### PR TITLE
CTA plugin updates

### DIFF
--- a/assets/scss/6-components/cta-block/_cta-block.scss
+++ b/assets/scss/6-components/cta-block/_cta-block.scss
@@ -7,15 +7,15 @@
 //
 // Styleguide 6.0.1
 
-$cta-block-min-col: px-to-rem(160px);
+$cta-block-min-col: px-to-rem(140px);
 $cta-block-btn-height: px-to-rem(29px);
 
 .c-cta-block {
-  border: 1px solid $color-white-off;
+  border: 1px solid $color-gray-light;
   border-radius: $border-radius-b;
 
   &__btns {
-    @include gap;
+    @include gap($size-xxs);
     display: grid;
     grid-auto-rows: $cta-block-btn-height;
     grid-template-columns: 1fr 1fr;

--- a/assets/scss/6-components/cta-block/cta-block.html
+++ b/assets/scss/6-components/cta-block/cta-block.html
@@ -1,28 +1,28 @@
 <!-- note: strong tags in h4s only used for demo -->
 
 <!-- Social Follow CTA -->
-<div class="c-cta-block has-padding has-giant-btm-marg">
+<div class="c-cta-block has-xl-padding has-giant-btm-marg">
   <div class="c-cta-block__msg t-size-s">
-    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-s-btm-marg"><strong>Stay in the loop</strong></h4>
-    <p class="has-s-btm-marg t-size-m"><strong>The next time news breaks, hear about it first.</strong></p>
+    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-xxs-btm-marg"><strong>Stay in the loop</strong></h4>
+    <p class="has-xxs-btm-marg t-size-m"><strong>The next time news breaks, hear about it first.</strong></p>
     <p class="has-text-gray t-linkstyle t-linkstyle--underlined">Follow The Texas Tribune on <a href="#">Facebook</a> and <a href="#">Twitter</a>.</p>
   </div>
   <div class="c-cta-block__btns t-align-center">
-      <a class="c-button c-button--outline has-text-facebook has-bg-facebook has-text-hover-facebook l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
+      <a class="c-button has-bg-facebook l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
         <span class="c-button__inner t-size-xxs">Facebook</span>
       </a>
-    <a 
-      class="c-button c-button--outline has-text-twitter has-bg-twitter has-text-hover-twitter l-align-center-children has-reset-padding" href="#" aria-label="Share on Twitter">
+    <a
+      class="c-button has-bg-twitter l-align-center-children has-reset-padding" href="#" aria-label="Share on Twitter">
         <span class="c-button__inner t-size-xxs">Twitter</span>
     </a>
   </div>
 </div>
 
 <!-- Membership CTA -->
-<div class="c-cta-block has-padding">
+<div class="c-cta-block has-xl-padding">
   <div class="c-cta-block__msg t-size-s">
-    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-s-btm-marg"><strong>Join our nonprofit newsroom</strong></h4>
-    <p class="has-s-btm-marg t-size-m"><strong>Support our voting rights coverage by becoming a Texas Tribune member today.</strong></p>
+    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-xxs-btm-marg"><strong>Join our nonprofit newsroom</strong></h4>
+    <p class="has-xxs-btm-marg t-size-m"><strong>Support our voting rights coverage by becoming a Texas Tribune member today.</strong></p>
     <p class="has-text-gray t-linkstyle t-linkstyle--underlined">Choose an amount to give or <a href="#" class="l-display-ib">learn more about membership</a>.</p>
   </div>
   <div class="c-cta-block__btns c-cta-block__btns--1x4 t-align-center t-size-s">


### PR DESCRIPTION
#### What's this PR do?

Style fixes for cta plugins.

#### Why are we doing this? How does it help us?

After seeing it in context of a story, we needed to add some adjustments.

#### How should this be manually tested?
`yarn dev`

See: [cta-block](http://localhost:3000/pages/components/index.html#cta-block-c-cta-block)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

It's mostly just changes to the demo, but I also needed some component-level update. Let's call this a patch


#### TODOs / next steps:

* [ ] *Incorporate into [tt PR](https://github.com/texastribune/texastribune/pull/3639) and remove those extra styles added*
