### PR TITLE
Add swap for lighthouse and perhaps viz complete?

### DIFF
--- a/assets/scss/5-typography/_font-families.scss
+++ b/assets/scss/5-typography/_font-families.scss
@@ -1,4 +1,5 @@
 @font-face {
+  font-display: swap;
   font-family: 'PT Serif';
   src: url('https://cdn.texastribune.org/fonts/ptserif-regular.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/ptserif-regular.woff') format('woff');
@@ -7,6 +8,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: 'PT Serif';
   src: url('https://cdn.texastribune.org/fonts/ptserif-bold.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/ptserif-bold.woff') format('woff');
@@ -15,6 +17,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: 'PT Serif';
   src: url('https://cdn.texastribune.org/fonts/ptserif-italic.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/ptserif-italic.woff') format('woff');
@@ -23,6 +26,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: 'PT Serif';
   src: url('https://cdn.texastribune.org/fonts/ptserif-bolditalic.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/ptserif-bolditalic.woff') format('woff');
@@ -31,6 +35,7 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: 'Open Sans';
   src: url('https://cdn.texastribune.org/fonts/opensans-regular.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/opensans-regular.woff') format('woff');


### PR DESCRIPTION
#### What's this PR do?
Adds `font-display: swap` to our fonts

#### Why are we doing this? How does it help us?

Lighthouse suggests it and there's an unexplained uptick in our visually complete metric. I thought font-face observer made this property obsolete, but maybe it has a slight benefit. This also hurts 0%.


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Just a patch

