### PR TITLE
Simplify nav spacing

### DIFF
--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -55,7 +55,13 @@
   &__items {
     display: flex;
     list-style: none;
-    margin-right: $size-m;
+    margin-right: $size-xxl;
+
+    // useful override for when you have another adjacent `.c-navbar__items` that's hidden;
+    // in that case, you'll get unwanted right margin because your element isn't the last child
+    &--no-space {
+      margin-right: 0;
+    }
 
     &:last-child {
       margin-right: 0;
@@ -65,6 +71,12 @@
   &__item {
     display: flex;
     margin-right: $size-b;
+
+    // useful override for when you have another adjacent `.c-navbar__items` that's hidden;
+    // in that case, you'll get unwanted right margin because your element isn't the last child
+    &--no-space {
+      margin-right: 0;
+    }
 
     &:last-child {
       margin-right: 0;
@@ -136,6 +148,8 @@
     padding: $size-b/2 0 0 0;
   }
 
+  // bottom margin is so you can have multiple sets of dropdown items (for example
+  // one with nav links, one with log in/log out buttons) that are spaced a bit
   &__dropdown-items {
     display: flex;
     flex-wrap: wrap;

--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -55,17 +55,19 @@
   &__items {
     display: flex;
     list-style: none;
+    margin-right: $size-m;
+
+    &:last-child {
+      margin-right: 0;
+    }
   }
 
   &__item {
     display: flex;
+    margin-right: $size-b;
 
-    &--space-right {
-      margin-right: $size-m;
-    }
-
-    &--giant-space-right {
-      margin-right: $size-giant;
+    &:last-child {
+      margin-right: 0;
     }
   }
 
@@ -138,6 +140,11 @@
     display: flex;
     flex-wrap: wrap;
     list-style: none;
+    margin-bottom: $size-xxxs;
+
+    &:last-of-type {
+      margin-bottom: 0;
+    }
   }
 
   &__dropdown-item {

--- a/assets/scss/6-components/navbar/navbar.html
+++ b/assets/scss/6-components/navbar/navbar.html
@@ -6,18 +6,18 @@
     
     <div class="c-navbar__content">
       <ul class="c-navbar__items is-hidden-until-bp-l">
-        <li class="c-navbar__item c-navbar__item--space-right">
+        <li class="c-navbar__item">
           <a href="#" class="is-active c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
             <strong>Link 1</strong>
           </a>
         </li>
-        <li class="c-navbar__item c-navbar__item--space-right">
+        <li class="c-navbar__item">
           <a href="#"
             class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
             <strong>Link 2</strong>
           </a>
         </li>
-        <li class="c-navbar__item c-navbar__item--space-right">
+        <li class="c-navbar__item">
           <a href="#"
             class="c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
             <strong>Link 3</strong>

--- a/assets/scss/6-components/navbar/navbar.html
+++ b/assets/scss/6-components/navbar/navbar.html
@@ -5,7 +5,7 @@
     </a>
     
     <div class="c-navbar__content">
-      <ul class="c-navbar__items is-hidden-until-bp-l">
+      <ul class="c-navbar__items c-navbar__items--no-space is-hidden-until-bp-l">
         <li class="c-navbar__item">
           <a href="#" class="is-active c-navbar__item-content c-navbar__clickable c-navbar__clickable--animated t-size-xxs t-uppercase t-uppercase--extra-wide">
             <strong>Link 1</strong>
@@ -35,7 +35,7 @@
         You'll need to toggle between "menu" and "close" with some JS
       -->
       <ul class="c-navbar__items is-hidden-from-bp-l">
-        <li class="c-navbar__item">
+        <li class="c-navbar__item c-navbar__item--no-space">
           <button aria-label="Show menu" class="c-navbar__item-content c-navbar__clickable t-size-xxs t-uppercase t-uppercase--extra-wide">
             <span class="c-icon">
               <svg aria-hidden="true" focusable="false">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "3.2.6",
+  "version": "4.0.0-0",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "4.0.0-0",
+  "version": "4.0.0-1",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",


### PR DESCRIPTION
#### What's this PR do?
Simplifies spacing classes on the navigation. Instead of having to put `--space-right` or `--giant-space-right` on stuff, those margins are now baked in with some available overrides and `:last-child` rules. This simplifies the markup greatly. One of the main reasons we needed the more verbose modifiers was because we didn't have access to React fragments in our `texastribune` navigation. Now, we do.

Also allows for two slightly-spaced rows of items in the mobile dropdown (to distinguish between regular links and action links like "log out").

##### Classes added (if any)
- Modifies some existing ones

##### Classes removed (if any)
- `c-navbar-item--giant-space-right`
- `c-navbar-item--space-right`

#### Why are we doing this? How does it help us?
Cleaner CSS.

#### How should this be manually tested?
+ `yarn dev`
+ See navbar example and ensure it looks OK.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
I'll create a major release for this (after a few test pre-releases) since it'll require markup changes in `texastribune` and UMP.