### PR TITLE
Handle fade logic in is-transparent and give back-to-top breathing room

### DIFF
--- a/assets/scss/6-components/back-to-top/_back-to-top.scss
+++ b/assets/scss/6-components/back-to-top/_back-to-top.scss
@@ -9,14 +9,12 @@
 .c-back-to-top {
   bottom: $size-s;
   left: 100%;
-  opacity: 1;
   padding-right: $size-s;
   pointer-events: none;
   position: sticky;
-  transition: opacity .3s;
   // Safari won't allow inline-block; we need a width for positioning.
   // If this grows in the future, consider making this a variation.
-  width: 4rem;
+  width: 6rem;
 
   &__inner {
     pointer-events: all;

--- a/assets/scss/utilities/_hidden.scss
+++ b/assets/scss/utilities/_hidden.scss
@@ -32,6 +32,7 @@
 // ^ including a duplicate class of .hidden right now since it's so littered throughout the code base.
 
 .is-transparent {
+  transition: opacity .3s;
   opacity: 0;
   z-index: -1;
 }


### PR DESCRIPTION
#### What's this PR do?
Back to top button fix

#### Why are we doing this? How does it help us?

The back to top button on the donor wall needs some breathing room.


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope


#### TODOs / next steps:

* [ ] *your TODO here*
