### PR TITLE
Add pruned CSS view for one-off projects (native ads in this case)

### DIFF
--- a/assets/scss/no-resets.scss
+++ b/assets/scss/no-resets.scss
@@ -6,12 +6,9 @@
 @import '1-settings/all';
 @import '2-tools/all';
 @import '5-typography/byline';
-@import '5-typography/description';
 @import '5-typography/headline';
-@import '5-typography/linkstyle';
-@import '5-typography/prose';
+@import '5-typography/links';
 @import '5-typography/sectionhead';
-@import '5-typography/smallcaps';
 @import '5-typography/t-helpers';
 @import '5-typography/t-size';
 @import '6-components/all';

--- a/assets/scss/no-resets.scss
+++ b/assets/scss/no-resets.scss
@@ -5,8 +5,15 @@
 // Styleguide 0.0.1
 @import '1-settings/all';
 @import '2-tools/all';
-@import '4-elements/all';
-@import '5-typography/all';
+@import '5-typography/byline';
+@import '5-typography/description';
+@import '5-typography/headline';
+@import '5-typography/linkstyle';
+@import '5-typography/prose';
+@import '5-typography/sectionhead';
+@import '5-typography/smallcaps';
+@import '5-typography/t-helpers';
+@import '5-typography/t-size';
 @import '6-components/all';
 @import '7-layout/all';
 @import 'utilities/all';

--- a/docs/config/tasks/docs.js
+++ b/docs/config/tasks/docs.js
@@ -14,6 +14,7 @@ const htmlRunner = require('./html');
 const { docsStyles, docsIcons, mappedGithubData } = require('../paths.js');
 
 const COMPONENT_CSS_FILE = 'all.css';
+const COMPONENT_CSS_FILE_MIN = 'no-resets.css';
 const LEGACY_CSS_FILE = 'all-legacy.css';
 const COMPONENT_CSS_PATH = './docs/dist/css';
 
@@ -34,13 +35,31 @@ const clean = async (html, deprecated) => {
       },
     ],
   });
+  const filePathMin = `${COMPONENT_CSS_PATH}/${COMPONENT_CSS_FILE_MIN}`;
+  const purgecssMin = new Purgecss({
+    content: [html],
+    css: [filePathMin],
+    extractors: [
+      {
+        extractor: purgeHtml,
+        extensions: ['html'],
+      },
+    ],
+  });
   const file = path.basename(html, path.extname(html));
   const dir = path.dirname(html);
   const purgecssResult = await purgecss.purge();
   const purgecssParsed = purgecssResult[0].css;
+  const purgecssResultMin = await purgecssMin.purge();
+  const purgecssParsedMin = purgecssResultMin[0].css;
   // create a css file
   try {
     await fs.outputFile(`${dir}/${file}.css`, purgecssParsed);
+  } catch (err) {
+    throw err;
+  }
+  try {
+    await fs.outputFile(`${dir}/${file}-min.css`, purgecssParsedMin);
   } catch (err) {
     throw err;
   }

--- a/docs/config/tasks/docs.js
+++ b/docs/config/tasks/docs.js
@@ -18,34 +18,31 @@ const COMPONENT_CSS_FILE_MIN = 'no-resets.css';
 const LEGACY_CSS_FILE = 'all-legacy.css';
 const COMPONENT_CSS_PATH = './docs/dist/css';
 
+const purge = (html, filePath) => {
+  return new Purgecss({
+    content: [html],
+    css: [filePath],
+    keyframes: true,
+    extractors: [
+      {
+        extractor: purgeHtml,
+        extensions: ['html'],
+      },
+    ],
+  });
+};
+
 const clean = async (html, deprecated) => {
   let css = COMPONENT_CSS_FILE;
   if (deprecated) {
     css = LEGACY_CSS_FILE;
   }
-
   const filePath = `${COMPONENT_CSS_PATH}/${css}`;
-  const purgecss = new Purgecss({
-    content: [html],
-    css: [filePath],
-    extractors: [
-      {
-        extractor: purgeHtml,
-        extensions: ['html'],
-      },
-    ],
-  });
   const filePathMin = `${COMPONENT_CSS_PATH}/${COMPONENT_CSS_FILE_MIN}`;
-  const purgecssMin = new Purgecss({
-    content: [html],
-    css: [filePathMin],
-    extractors: [
-      {
-        extractor: purgeHtml,
-        extensions: ['html'],
-      },
-    ],
-  });
+
+  const purgecss = purge(html, filePath);
+  const purgecssMin = purge(html, filePathMin);
+
   const file = path.basename(html, path.extname(html));
   const dir = path.dirname(html);
   const purgecssResult = await purgecss.purge();

--- a/docs/src/macros/snippet.html
+++ b/docs/src/macros/snippet.html
@@ -16,8 +16,8 @@
             <pre class="has-text-info">.{{mainClass}}</pre>
         {% endif %}
         <div class="ds-icon buttons">
-            <a class="button is-primary" fill="#fff" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-preview.html">Standalone&nbsp;<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" /></svg></a>
-            <a class="button is-primary" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-min.css">Standalone CSS</a>
+            <a class="button is-primary" fill="#fff" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-preview.html">Preview&nbsp;<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" /></svg></a>
+            <a class="button is-primary" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-min.css">CSS</a>
         </div>
     </div>
     {% endif %}

--- a/docs/src/macros/snippet.html
+++ b/docs/src/macros/snippet.html
@@ -17,6 +17,7 @@
         {% endif %}
         <div class="ds-icon buttons">
             <a class="button is-primary" fill="#fff" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-preview.html">Standalone&nbsp;<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" /></svg></a>
+            <a class="button is-primary" target="_blank" rel="noopener noreferrer" href="{{mainClass}}/raw-min.css">Standalone CSS</a>
         </div>
     </div>
     {% endif %}

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -117,7 +117,7 @@
                 </div>
               {% else %}
                 <div class="column is-full">
-                  <a class="button is-primary" target="_blank" rel="noopener noreferrer" href="{{item.mainClass}}/raw-preview.html">Standalone&nbsp;<svg fill="#fff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" /></svg></a>
+                  <a class="button is-primary" target="_blank" rel="noopener noreferrer" href="{{item.mainClass}}/raw-preview.html">Preview&nbsp;<svg fill="#fff" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path d="M21 13v10h-21v-19h12v2h-10v15h17v-8h2zm3-12h-10.988l4.035 4-6.977 7.07 2.828 2.828 6.977-7.07 4.125 4.172v-11z" /></svg></a>
                 </div>
               {% endif %}
               {% if (item.modifiers|length) and ( item.groupName === 'Typography' or item.groupName === 'Utility') %}

--- a/docs/src/preview-raw.html
+++ b/docs/src/preview-raw.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
-  <title>{{mainClass}} | Standalone</title>
+  <title>{{mainClass}} | Preview</title>
 </head>
 <body style="margin: 20px;border:1px dashed gray">
 <div style="display: none">


### PR DESCRIPTION
#### What's this PR do?

Adds a new link to pruned CSS for individual components and helpers.


#### Why are we doing this? How does it help us?

 Sometimes we don't want to import the whole system, but we just want the styles. Example: Ad native ad which is served from an iframe (which doesn't inherit parent CSS)

![Screen Shot 2019-10-08 at 9 42 04 AM](https://user-images.githubusercontent.com/2974713/66406029-97189f80-e9b0-11e9-9295-0a62a0247739.png)

The CSS generated in the prune CSS step only includes classes referenced in the HTML and does not include normalize.

#### How should this be manually tested?
`yarn dev`

See new CSS button


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Doesn't even require a release. Docs change only.


#### TODOs / next steps:

* [ ] *your TODO here*
