### PR TITLE
Remove unused fonts

### DIFF
--- a/assets/scss/5-typography/_font-families.scss
+++ b/assets/scss/5-typography/_font-families.scss
@@ -44,25 +44,10 @@
 }
 
 @font-face {
+  font-display: swap;
   font-family: 'Open Sans';
   src: url('https://cdn.texastribune.org/fonts/opensans-bold.woff2') format('woff2'),
     url('https://cdn.texastribune.org/fonts/opensans-bold.woff') format('woff');
   font-weight: 700;
   font-style: normal;
-}
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('https://cdn.texastribune.org/fonts/opensans-italic.woff2') format('woff2'),
-    url('https://cdn.texastribune.org/fonts/opensans-italic.woff') format('woff');
-  font-weight: 400;
-  font-style: italic;
-}
-
-@font-face {
-  font-family: 'Open Sans';
-  src: url('https://cdn.texastribune.org/fonts/opensans-bolditalic.woff2') format('woff2'),
-    url('https://cdn.texastribune.org/fonts/opensans-bolditalic.woff') format('woff');
-  font-weight: 700;
-  font-style: italic;
 }


### PR DESCRIPTION
#### What's this PR do?
- Adds a missing `font-display: swap`. Not sure how I missed that the first time around.
- Removes Open Sans italic and Open Sans italic-bold

#### Why are we doing this? How does it help us?
- The swap is just because we use it on the others.
- Removing those italics of Open Sans is because I don't think we actually ever use them.

The case for leaving them there 🤔 
I could also be convinced to leave those two declarations because it's my understanding that technically that font is never downloaded anyway. Since the CSS never calls for that combo of `font-family: Open Sans` and `font-style: italic`, the browser never reaches the point of requesting the file. I think this because of [bullet under #4 here](https://developers.google.com/web/fundamentals/performance/optimizing-content-efficiency/webfont-optimization#the_default_behavior): 
> Font requests are dispatched after the render tree indicates which font variants are needed to render the specified text on the page

@AndrewGibson27, I know you're out for a bit, but let me know what you think when you're back.
