### PR TITLE
Allow ordered lists in story body

### DIFF
--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -17,6 +17,7 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
   > h5,
   > h6,
   > ul,
+  > ol,
   > span,
   > hr {
     max-width: $story-narrow;
@@ -29,13 +30,14 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
 
   > p,
   > h3,
-  > ul li {
+  > ul,
+  > ol {
     @include font-setting('secondary');
     @include underlined-link-parent;
   }
 
-  > ul {
-    list-style: disc;
+  > ul,
+  > ol {
     padding: 0 $size-b 0 3.5rem;
 
     li {
@@ -43,6 +45,9 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     }
   }
 
+  > ul {
+    list-style: disc;
+  }
 
   sub, sup {
     position: initial;

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -4,6 +4,20 @@
   <p>Use a horizontal rule to break up content. A horizontal rule is displayed below.</p>
   <hr/>
   <p>The hr tag has built in top and bottom margin. We do this because it's normally used as a spacing element and the need for cushion is assumed.</p>
+  <h3>Ordered Lists</h3>
+  <p>Ordered lists are lists with numbers and need the special container and a list style treatment.</p>
+  <ol>
+    <li>This is the first item.</li>
+    <li>This is the second item.</li>
+    <li>This is the third item.</li>
+  </ol>
+  <h3>Unordered Lists</h3>
+  <p>Unordered lists are lists with bullets and also need the special container and a list style treatment. We globally remove bullets so lists within the c-story-body class we add them back via the ul tag.</p>
+  <ul>
+    <li>This is the first item.</li>
+    <li>This is the second item.</li>
+    <li>This is the third item.</li>
+  </ul>
   <h3>Headings</h3>
   <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h3. In the event someone were to open the source and add others, this is how they would display.</p>
   <h2>Heading 2</h2>


### PR DESCRIPTION
#### What's this PR do?

Styles `ol`s with proper fonts, links, margins.

#### Why are we doing this? How does it help us?

The people need to order lists!

#### How should this be manually tested?
`yarn dev`

See: [c-story-body](http://localhost:3000/pages/components/c-story-body/raw-preview.html)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Net add. I'll add this as a patch, because I'd call this an oversight of mine in the first place.


#### TODOs / next steps:

* [ ] *Test in texastribune*
