### PR TITLE
Add feedback from paid-posts

### DIFF
--- a/assets/scss/6-components/info-drop/_info-drop.scss
+++ b/assets/scss/6-components/info-drop/_info-drop.scss
@@ -29,6 +29,8 @@ $info-drop-size: px-to-rem(14px);
 .c-info-drop {
   overflow: hidden;
   padding-bottom: $info-drop-size * 2;
+  position: sticky;
+  top: 0;
 
   &__inner {
     position: relative;

--- a/assets/scss/6-components/sponsor-block/_sponsor-block.scss
+++ b/assets/scss/6-components/sponsor-block/_sponsor-block.scss
@@ -7,7 +7,7 @@
 //
 // Styleguide 6.1.3
 $c-sponsor-block-padding: $size-s;
-$c-sponsor-block-min: 300px;
+$c-sponsor-block-min: 200px;
 
 .c-sponsor-block {
   @include gap($c-sponsor-block-padding);
@@ -26,9 +26,8 @@ $c-sponsor-block-min: 300px;
   }
 
   &__image {
-    height: 100%;
     object-fit: cover;
-    max-height: 300px;
+    max-height: 200px;
   }
 
   &__label {
@@ -37,12 +36,20 @@ $c-sponsor-block-min: 300px;
     top: $c-sponsor-block-padding;
   }
 
-  &__main {
-    align-self: flex-start;
-  }
-
   &__text {
     display: grid;
+  }
+
+  &__sponsor {
+    font-size: $size-xxs;
+  }
+
+  &__headline {
+    font-size: $size-b;
+  }
+
+  &__desc {
+    font-size: $size-xs;
   }
 
   @include mq($from: bp-m) {
@@ -50,12 +57,23 @@ $c-sponsor-block-min: 300px;
 
     &__label {
       position: static;
-      align-self: start;
     }
 
+    &__sponsor {
+      font-size: $size-xs;
+    }
+
+    &__headline {
+      font-size: $size-m;
+    }
+
+    &__desc {
+      font-size: $size-s;
+    }
+  }
+  @include mq($from: bp-l) {
     &__main {
       padding: 0 $c-sponsor-block-padding 0 $size-xxxl;
     }
-
   }
 }

--- a/assets/scss/6-components/sponsor-block/sponsor-block.html
+++ b/assets/scss/6-components/sponsor-block/sponsor-block.html
@@ -3,9 +3,9 @@
 	<div class="c-sponsor-block__text">
 		<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid Post</strong></span>
 		<div class="c-sponsor-block__main">
-			<h4 class="has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">TX Company 1234</h4>
-			<h3 class="t-serif t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit</a></h3>
-			<p class="t-serif t-size-s t-lh-m">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque, obcaecati suscipit! Ducimus soluta magnam ratione ullam eius repellat beatae tempora, quo ipsam alias porro voluptas a temporibus rerum maxime nisi.</p>
+			<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">TX Company 1234</h4>
+			<h3 class="c-sponsor-block__headline t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit</a></h3>
+			<p class="c-sponsor-block__desc t-lh-s">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque, obcaecati suscipit! Ducimus soluta magnam ratione ullam eius repellat beatae tempora, quo ipsam alias porro voluptas a temporibus rerum maxime nisi.</p>
 		</div>
 	</div>
 </aside>


### PR DESCRIPTION
#### What's this PR do?

- Shrinks down images/fonts in the sponsor ads
- Sticks `c-info-drop` to top

#### Why are we doing this? How does it help us?

We had to add some changes to make the sponsor block less prominent. This is all carried into Google Ad Manager, but I'm updating here as well to keep us up to date in our docs.

The info bar `position: sticky` request stemmed from the same goal of being transparent about paid posts. We want to make sure users don't bypass it and confuse our brand with another.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope


#### TODOs / next steps:

* [ ] *Bump to `5.1.5`*
