### PR TITLE
Small tweaks to event and CTA blocks

### DIFF
--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -93,3 +93,31 @@
   grid-gap: $size;
   gap: $size;
 }
+
+
+// @mixin row-gap
+//
+// This is to account for the eminent deprecation of [`grid-row-gap`]
+//
+// $size = $size-b - Size of gap
+//
+// Styleguide 2.1.3
+//
+@mixin row-gap($size: $size-b) {
+  grid-row-gap: $size;
+  row-gap: $size;
+}
+
+
+// @mixin col-gap
+//
+// This is to account for the eminent deprecation of [`grid-column-gap`]
+//
+// $size = $size-b - Size of gap
+//
+// Styleguide 2.1.3
+//
+@mixin col-gap($size: $size-b) {
+  grid-column-gap: $size;
+  column-gap: $size;
+}

--- a/assets/scss/6-components/block-grid/_block-grid.scss
+++ b/assets/scss/6-components/block-grid/_block-grid.scss
@@ -15,6 +15,10 @@
 
   @include mq($from: bp-m) {
     grid-template-columns: repeat(auto-fit, minmax(px-to-rem(300px), 1fr));
+
+    &--min-100 {
+      grid-template-columns: repeat(auto-fit, minmax(px-to-rem(100px), 1fr));
+    }
   }
 
   &--bordered {

--- a/assets/scss/6-components/block-grid/_block-grid.scss
+++ b/assets/scss/6-components/block-grid/_block-grid.scss
@@ -9,11 +9,12 @@
 //
 // Styleguide 6.1.3
 .c-block-grid {
-  @include gap($size-s);
+  @include col-gap($size-s);
+  @include row-gap($size-xxl);
   display: grid;
 
   @include mq($from: bp-m) {
-    grid-template-columns: repeat(auto-fit, minmax(100px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(px-to-rem(300px), 1fr));
   }
 
   &--bordered {

--- a/assets/scss/6-components/cta-block/_cta-block.scss
+++ b/assets/scss/6-components/cta-block/_cta-block.scss
@@ -23,7 +23,7 @@ $cta-block-btn-height: px-to-rem(29px);
     @include gap($size-xxs);
     display: grid;
     grid-auto-rows: $cta-block-btn-height;
-    margin-top: $cta-block-btn-height;
+    margin-top: $size-b;
 
     // four buttons, all in a row
     &--4 {

--- a/assets/scss/6-components/cta-block/_cta-block.scss
+++ b/assets/scss/6-components/cta-block/_cta-block.scss
@@ -23,7 +23,7 @@ $cta-block-btn-height: px-to-rem(29px);
     @include gap($size-xxs);
     display: grid;
     grid-auto-rows: $cta-block-btn-height;
-    margin-top: $size-b;
+    margin-top: $size-s;
 
     // four buttons, all in a row
     &--4 {

--- a/assets/scss/6-components/event-block/_event-block.scss
+++ b/assets/scss/6-components/event-block/_event-block.scss
@@ -28,7 +28,7 @@
   @include mq($from: bp-m) {
     &__content {
       &--overlay {
-        background: linear-gradient(rgba(0,0,0,0) -25%,#000);
+        background: linear-gradient(rgba(0,0,0,0) -100%,#000);
         color: #fff;
         position: absolute;
         left: 0;

--- a/assets/scss/6-components/event-block/_event-block.scss
+++ b/assets/scss/6-components/event-block/_event-block.scss
@@ -28,7 +28,7 @@
   @include mq($from: bp-m) {
     &__content {
       &--overlay {
-        background: linear-gradient(rgba(0,0,0,0) 60%,#000);
+        background: linear-gradient(rgba(0,0,0,0) -25%,#000);
         color: #fff;
         position: absolute;
         left: 0;

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -3,7 +3,7 @@
   Accomplished by using `.c-event-block__content--overlay` and modifiers
   on the `.c-cta-block` classes.
 -->
-<div class="c-event-block has-giant-btm-marg">
+<div class="c-event-block has-giant-btm-marg" aria-label="The Texas Tribune Festival">
   <figure>
     <a href="#" class="l-display-block">
       <img class="l-display-block l-width-full" src="/img/event-block/c-event-block-thumb.jpg" alt="Attendees of The Texas Tribune Festival in Moody Theater"/>
@@ -15,15 +15,17 @@
   </time>
   <div class="c-event-block__content c-event-block__content--overlay c-cta-block c-cta-block--horiz-from-m c-cta-block--no-border l-width-full">
     <div class="c-cta-block__msg t-size-s">
-      <h2 class="c-event-block__title t-serif t-size-l has-xxxs-btm-marg">The Texas Tribune Festival</h2>
-      <h3 class="t-uppercase t-lsp-b t-size-xs">Austin | 7 p.m. - 10 p.m.</h3>
+      <h3 class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-l" aria-hidden="true">
+        <a href="#" tabindex="-1">The Texas Tribune Festival</a>
+      </h3>
+      <p class="t-uppercase t-lsp-b t-size-xs">Held in Austin | 7 p.m. - 10 p.m.</p>
     </div>
     <div class="c-cta-block__btns c-cta-block__btns--2-stack-from-m t-align-center">
-      <a class="c-button c-button--standard has-bg-teal l-align-center-children" href="#">
-        <span class="c-button__inner t-size-xxs">Attend</span>
+      <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+        Attend
       </a>
-      <a class="c-button c-button--standard has-bg-gray-dark l-align-center-children" href="#">
-        <span class="c-button__inner t-size-xxs">Watch</span>
+      <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+        Watch
       </a>
     </div>
   </div>
@@ -33,7 +35,7 @@
   Event block with text and links always below the image.
   Accomplished by leaving off the `--overlay` modifier.
 -->
-<div class="c-event-block" style="max-width: 300px;">
+<div class="c-event-block" aria-label="The Texas Tribune Festival" style="max-width: 300px;">
   <figure>
     <a href="#" class="l-display-block">
       <img class="l-display-block l-width-full" src="/img/event-block/c-event-block-thumb.jpg" alt="Attendees of The Texas Tribune Festival in Moody Theater"/>
@@ -45,15 +47,17 @@
   </time>
   <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
     <div class="c-cta-block__msg t-size-s">
-      <h2 class="c-event-block__title t-serif t-size-l has-xxxs-btm-marg">The Texas Tribune Festival</h2>
-      <h3 class="t-uppercase t-lsp-b t-size-xs">Austin | 7 p.m. - 10 p.m.</h3>
+      <h3 class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m" aria-hidden="true">
+        <a href="#" tabindex="-1">The Texas Tribune Festival</a>
+      </h3>
+      <p class="t-uppercase t-lsp-b t-size-xs">Held in Austin | 7 p.m. - 10 p.m.</p>
     </div>
     <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center">
-      <a class="c-button c-button--standard has-bg-teal l-align-center-children" href="#">
-        <span class="c-button__inner t-size-xxs">Attend</span>
+      <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+        Attend
       </a>
-      <a class="c-button c-button--standard has-bg-gray-dark l-align-center-children" href="#">
-        <span class="c-button__inner t-size-xxs">Watch</span>
+      <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+        Watch
       </a>
     </div>
   </div>

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -18,7 +18,9 @@
       <h3 class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-l" aria-hidden="true">
         <a href="#" tabindex="-1">The Texas Tribune Festival</a>
       </h3>
-      <p class="t-uppercase t-lsp-b t-size-xs">Held in Austin | 7 p.m. - 10 p.m.</p>
+      <p class="t-uppercase t-lsp-b t-size-xs">
+        <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+      </p>
     </div>
     <div class="c-cta-block__btns c-cta-block__btns--2-stack-from-m t-align-center">
       <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
@@ -50,7 +52,9 @@
       <h3 class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m" aria-hidden="true">
         <a href="#" tabindex="-1">The Texas Tribune Festival</a>
       </h3>
-      <p class="t-uppercase t-lsp-b t-size-xs">Held in Austin | 7 p.m. - 10 p.m.</p>
+      <p class="t-uppercase t-lsp-b t-size-xs">
+        <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+      </p>
     </div>
     <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center">
       <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "6.0.2",
+  "version": "6.0.3-0",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "6.0.3-0",
+  "version": "6.0.3-1",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",


### PR DESCRIPTION
#### What's this PR do?
- Adds mixins for row and column gaps
- Increases row gap in `c-block-grid`
- Increases min column width in `c-block-grid`
- Increases gradient darkness in `c-event-block`
- Decreases space between text and buttons in `c-cta-block`

#### Why are we doing this? How does it help us?
These are all things we talked about on 10/31 related to the rug/drawer

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
This will be `6.0.3`. No markup changes required.

@ashley-hebler LMK if the increases min column width in `c-block-grid` will throw off the home-page work you're doing. Also, here are screen grabs of the two plugins using `c-cta-block`, now with decreased button top margin. IMO it looks fine but LMK if you feel otherwise.

![Screen Shot 2019-11-01 at 11 39 21 AM](https://user-images.githubusercontent.com/2243202/68040416-4721b580-fc9c-11e9-896e-80ed28f19811.png)