### PR TITLE
Prep sponsor content block for livin' in lazy world

### DIFF
--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -4,6 +4,7 @@
 //
 // Styleguide 6.0.0
 @import 'ad/ad';
+@import 'ad-fluid/ad-fluid';
 @import 'back-to-top/back-to-top';
 @import 'blast-header/blast-header';
 @import 'block-feed/block-feed';

--- a/assets/scss/6-components/ad-fluid/_ad-fluid.scss
+++ b/assets/scss/6-components/ad-fluid/_ad-fluid.scss
@@ -1,0 +1,26 @@
+// Ad fluid (c-ad-fluid)
+//
+// Currently, this is only intended to wrap around sponsor content ads, which are implemented through Google's native ad feature. Fluid ads contain more dynamic content than our standard set `height` x `width` ads, but we must still declare a height that the browser can anticipate before the ad content loads (aka prevent reflow). <br><br> **Note:** If we start to see more variations of fluid ads in the future, consider making the sponsor styles scoped under a specific modifier. {{isWide}}
+//
+// Markup: 6-components/ad-fluid/ad-fluid.html
+//
+// Styleguide 6.1.3
+
+
+.c-ad-fluid {
+  border-top: 5px solid $color-sponsor;
+  border-bottom: 2px solid $color-sponsor;
+  height: 400px;
+
+  @include mq($from: bp-xs) {
+    height: 365px;
+  }
+
+  @include mq($from: bp-s) {
+    height: 380px;
+  }
+
+  @include mq($from: bp-m) {
+    height: 240px;
+  }
+}

--- a/assets/scss/6-components/ad-fluid/ad-fluid.html
+++ b/assets/scss/6-components/ad-fluid/ad-fluid.html
@@ -1,0 +1,3 @@
+<div class="c-ad-fluid has-bg-white-off">
+  <div style="display: grid; height: 100%; padding: 20px;"><div style="border: 1px dotted #000; padding: 20px;">Native ad goes here</div></div>
+</div>

--- a/assets/scss/6-components/sponsor-block/_sponsor-block.scss
+++ b/assets/scss/6-components/sponsor-block/_sponsor-block.scss
@@ -6,12 +6,12 @@
 // Markup: 6-components/sponsor-block/sponsor-block.html
 //
 // Styleguide 6.1.3
+$sb-headline-lines: 2;
 $sb-desc-lines: 3;
 
 .c-sponsor-block {
   @include gap($size-s);
-  border-top: 5px solid $color-sponsor;
-  border-bottom: 2px solid $color-sponsor;
+  
   display: grid;
   grid-template-areas: 'image-wrap' 'text';
   grid-template-columns: 1fr;
@@ -37,19 +37,25 @@ $sb-desc-lines: 3;
     font-size: $size-xxs;
   }
 
+  &__static-text {
+    display: -webkit-box;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-box-orient: vertical;
+  }
+
   &__headline {
     font-size: $size-b;
+    max-height: $size-b * $font-line-height-m * $sb-headline-lines; // Fallback for non-webkit
+    line-height: $font-line-height-s;
+    -webkit-line-clamp: $sb-headline-lines;
   }
 
   &__desc {
-    display: -webkit-box;
     font-size: $size-xs;
     height: $size-xs * $font-line-height-m * $sb-desc-lines; // Fallback for non-webkit
     line-height: $font-line-height-m;
-    overflow: hidden;
-    text-overflow: ellipsis;
     -webkit-line-clamp: $sb-desc-lines;
-    -webkit-box-orient: vertical;
   }
 
   &__image-wrap {
@@ -79,6 +85,7 @@ $sb-desc-lines: 3;
 
     &__headline {
       font-size: $size-m;
+      max-height: $size-m * $font-line-height-s * $sb-headline-lines;
     }
 
     &__desc {
@@ -91,4 +98,35 @@ $sb-desc-lines: 3;
       padding: 0 $size-s 0 $size-xxxl;
     }
   }
+}
+
+
+.c-fluid-ad {
+  border-top: 5px solid $color-sponsor;
+  border-bottom: 2px solid $color-sponsor;
+  display: flex;
+  align-items: center;
+  background-color: $color-white-off;
+  margin: 2rem 0;
+  height: 400px;
+  margin-left: auto;
+  margin-right: auto;
+  max-width: 1080px;
+
+  @include mq($from: bp-xs) {
+    height: 365px;
+  }
+
+  @include mq($from: bp-s) {
+    height: 380px;
+  }
+
+  @include mq($from: bp-m) {
+    height: 250px;
+  }
+}
+
+// demo lazy
+.c-sponsor-block {
+  opacity: 0;
 }

--- a/assets/scss/6-components/sponsor-block/_sponsor-block.scss
+++ b/assets/scss/6-components/sponsor-block/_sponsor-block.scss
@@ -1,7 +1,8 @@
 // Sponsor block (c-sponsor-block)
 //
-// Sponsor block is a promotional element featuring a paid post. The goal of this approach is to be minimally reliant on media queries; the inner content should scale appropriately to any size of parent container.
+// Sponsor block is a promotional element featuring a paid post. When loaded lazily, wrap this component in `c-ad-fluid`. {{isWide}}
 //
+// c-sponsor-block--filled - This version includes a border/bg color. It can be dropped after lazy ads rolls out and c-sponsor-block becomes coupled with `c-ad-fluid`.
 //
 // Markup: 6-components/sponsor-block/sponsor-block.html
 //
@@ -11,7 +12,6 @@ $sb-desc-lines: 3;
 
 .c-sponsor-block {
   @include gap($size-s);
-  
   display: grid;
   grid-template-areas: 'image-wrap' 'text';
   grid-template-columns: 1fr;
@@ -66,6 +66,12 @@ $sb-desc-lines: 3;
     grid-area: text;
   }
 
+  &--filled {
+    background-color: $color-white-off;
+    border-top: 5px solid $color-sponsor;
+    border-bottom: 2px solid $color-sponsor;
+  }
+
   @include mq($from: bp-m) {
     grid-template-areas: 'text image-wrap';
     grid-template-columns: repeat(auto-fit, minmax(200px, auto));
@@ -98,35 +104,4 @@ $sb-desc-lines: 3;
       padding: 0 $size-s 0 $size-xxxl;
     }
   }
-}
-
-
-.c-fluid-ad {
-  border-top: 5px solid $color-sponsor;
-  border-bottom: 2px solid $color-sponsor;
-  display: flex;
-  align-items: center;
-  background-color: $color-white-off;
-  margin: 2rem 0;
-  height: 400px;
-  margin-left: auto;
-  margin-right: auto;
-  max-width: 1080px;
-
-  @include mq($from: bp-xs) {
-    height: 365px;
-  }
-
-  @include mq($from: bp-s) {
-    height: 380px;
-  }
-
-  @include mq($from: bp-m) {
-    height: 240px;
-  }
-}
-
-// demo lazy
-.c-sponsor-block {
-  opacity: 0;
 }

--- a/assets/scss/6-components/sponsor-block/_sponsor-block.scss
+++ b/assets/scss/6-components/sponsor-block/_sponsor-block.scss
@@ -122,7 +122,7 @@ $sb-desc-lines: 3;
   }
 
   @include mq($from: bp-m) {
-    height: 250px;
+    height: 240px;
   }
 }
 

--- a/assets/scss/6-components/sponsor-block/_sponsor-block.scss
+++ b/assets/scss/6-components/sponsor-block/_sponsor-block.scss
@@ -6,34 +6,27 @@
 // Markup: 6-components/sponsor-block/sponsor-block.html
 //
 // Styleguide 6.1.3
-$c-sponsor-block-padding: $size-s;
-$c-sponsor-block-min: 200px;
+$sb-desc-lines: 3;
 
 .c-sponsor-block {
-  @include gap($c-sponsor-block-padding);
+  @include gap($size-s);
   border-top: 5px solid $color-sponsor;
   border-bottom: 2px solid $color-sponsor;
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax($c-sponsor-block-min, auto));
-  padding: ($c-sponsor-block-padding * 3) $c-sponsor-block-padding
-    $c-sponsor-block-padding;
+  grid-template-areas: 'image-wrap' 'text';
+  grid-template-columns: 1fr;
+  padding: $size-giant $size-s $size-s;
   position: relative;
-  direction: rtl;
-
-  &__text,
-  &__label {
-    direction: ltr;
-  }
 
   &__image {
     object-fit: cover;
-    max-height: 200px;
+    height: 160px;
   }
 
   &__label {
-    left: $c-sponsor-block-padding;
+    left: $size-s;
     position: absolute;
-    top: $c-sponsor-block-padding;
+    top: $size-s;
   }
 
   &__text {
@@ -49,11 +42,32 @@ $c-sponsor-block-min: 200px;
   }
 
   &__desc {
+    display: -webkit-box;
     font-size: $size-xs;
+    height: $size-xs * $font-line-height-m * $sb-desc-lines; // Fallback for non-webkit
+    line-height: $font-line-height-m;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    -webkit-line-clamp: $sb-desc-lines;
+    -webkit-box-orient: vertical;
+  }
+
+  &__image-wrap {
+    grid-area: image-wrap;
+  }
+
+  &__text {
+    grid-area: text;
   }
 
   @include mq($from: bp-m) {
-    padding-top: $c-sponsor-block-padding;
+    grid-template-areas: 'text image-wrap';
+    grid-template-columns: repeat(auto-fit, minmax(200px, auto));
+    padding-top: $size-s;
+
+    &__image {
+      height: 200px;
+    }
 
     &__label {
       position: static;
@@ -69,11 +83,12 @@ $c-sponsor-block-min: 200px;
 
     &__desc {
       font-size: $size-s;
+      height: $size-s * $font-line-height-m * $sb-desc-lines;
     }
   }
   @include mq($from: bp-l) {
     &__main {
-      padding: 0 $c-sponsor-block-padding 0 $size-xxxl;
+      padding: 0 $size-s 0 $size-xxxl;
     }
   }
 }

--- a/assets/scss/6-components/sponsor-block/sponsor-block.html
+++ b/assets/scss/6-components/sponsor-block/sponsor-block.html
@@ -3,10 +3,10 @@
 		<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
 				Post</strong></span>
 		<div class="c-sponsor-block__main">
-			<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">Texas Company ABC 123</h4>
-			<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxxs-btm-marg"><a href="#"
-					class="has-text-black-off">This is a headline for a sponsor block. The headline is truncated if it exceeds three lines.</a></h3>
-			<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis, impedit amet? Eligendi harum beatae in numquam labore ipsa quasi enim aut ipsum, quibusdam, iste voluptates, quisquam exercitationem assumenda blanditiis esse.</a></p>
+			<p class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg"><strong>Texas Company ABC 123</strong></p>
+			<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-lh-s has-xxxs-btm-marg"><a href="#"
+					class="has-text-black-off has-text-hover-black">This is a headline for a sponsor block. The headline is truncated if it exceeds three lines.</a></h3>
+			<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off has-text-hover-black">Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis, impedit amet? Eligendi harum beatae in numquam labore ipsa quasi enim aut ipsum, quibusdam, iste voluptates, quisquam exercitationem assumenda blanditiis esse.</a></p>
 		</div>
 	</div>
 	<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="/img/sponsor-block/c-sponsor-block-thumb.jpg" class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>

--- a/assets/scss/6-components/sponsor-block/sponsor-block.html
+++ b/assets/scss/6-components/sponsor-block/sponsor-block.html
@@ -1,87 +1,13 @@
-<div class="c-fluid-ad">
-	<aside class="c-sponsor-block">
-		<div class="c-sponsor-block__text">
-			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
-					Post</strong></span>
-			<div class="c-sponsor-block__main">
-				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">WGU TEXAS</h4>
-				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
-						class="has-text-black-off">Expanded broadband access lifts limits on human potential</a></h3>
-				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">With expanded broadband access you
-						reap what you sow – a smarter, healthier, more prosperous Texas.</a></p>
-			</div>
+<aside class="c-sponsor-block {{ className }}">
+	<div class="c-sponsor-block__text">
+		<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
+				Post</strong></span>
+		<div class="c-sponsor-block__main">
+			<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">Texas Company ABC 123</h4>
+			<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxxs-btm-marg"><a href="#"
+					class="has-text-black-off">This is a headline for a sponsor block. The headline is truncated if it exceeds three lines.</a></h3>
+			<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit. Omnis, impedit amet? Eligendi harum beatae in numquam labore ipsa quasi enim aut ipsum, quibusdam, iste voluptates, quisquam exercitationem assumenda blanditiis esse.</a></p>
 		</div>
-		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img
-				src="https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDnn6nRXhABGAEyCP4dyvqQGOGJ"
-				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
-	</aside>
-</div>
-
-<div class="c-fluid-ad">
-	<aside class="c-sponsor-block">
-		<div class="c-sponsor-block__text">
-			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
-					Post</strong></span>
-			<div class="c-sponsor-block__main">
-				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">HOGG FOUNDATION FOR MENTAL HEALTH</h4>
-				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
-						class="has-text-black-off">For World Mental Health Day, take 40 seconds</a></h3>
-				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Forty seconds is enough time to
-						make a difference that could save a life. It can also be the pivot point for a new national consensus that
-						makes our communities happier, healthier, and more equal.</a></p>
-			</div>
-		</div>
-		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img
-				src="https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCn5IDkSBABGAEyCKzHvMxYuF6R"
-				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
-	</aside>
-</div>
-
-
-
-<div class="c-fluid-ad">
-	<aside class="c-sponsor-block">
-		<div class="c-sponsor-block__text">
-			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
-					Post</strong></span>
-			<div class="c-sponsor-block__main">
-				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">AUSTIN
-					COMMUNITY FOUNDATION</h4>
-				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
-						class="has-text-black-off">2020 Census: Billions are at stake</a></h3>
-				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Overcoming the challenges facing
-						the 2020 Census will not be easy. All Texans have a role to play in ensuring an accurate count.</a></p>
-			</div>
-		</div>
-		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="
-	https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDn39r8KRABGAEyCGeabWxetsEq"
-				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
-	</aside>
-</div>
-
-
-
-
-
-
-<script>
-	const blocks = document.querySelectorAll('aside');
-	let timer = 1000;
-	blocks.forEach(block => {
-		timer = timer + 1000;
-		setTimeout(() => {
-			block.style.opacity = 1;
-		}, timer);
-	});
-	// var onresize = function() {
-	// 	console.log('=================');
-	// 	blocks.forEach(block => {
-	// 		const title = block.querySelector('h3 a').textContent;
-	// 		console.log(`${title}: ${block.clientHeight}`);
-	// 	});
-	// }
-	// window.addEventListener("resize", onresize);
-</script>
-
-
-
+	</div>
+	<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="/img/sponsor-block/c-sponsor-block-thumb.jpg" class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
+</aside>

--- a/assets/scss/6-components/sponsor-block/sponsor-block.html
+++ b/assets/scss/6-components/sponsor-block/sponsor-block.html
@@ -1,11 +1,11 @@
 <aside class="c-sponsor-block has-bg-white-off">
-	<a href="#" class="l-display-block"><img src="/img/sponsor-block/c-sponsor-block-thumb.jpg" class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
 	<div class="c-sponsor-block__text">
 		<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid Post</strong></span>
 		<div class="c-sponsor-block__main">
 			<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">TX Company 1234</h4>
 			<h3 class="c-sponsor-block__headline t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit</a></h3>
-			<p class="c-sponsor-block__desc t-lh-m">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque, obcaecati suscipit! Ducimus soluta magnam ratione ullam eius repellat beatae tempora, quo ipsam alias porro voluptas a temporibus rerum maxime nisi.</p>
+			<p class="c-sponsor-block__desc t-lh-m"><a href="#" class="has-text-black-off">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque, obcaecati suscipit! Ducimus soluta magnam ratione ullam eius repellat beatae tempora, quo ipsam alias porro voluptas a temporibus rerum maxime nisi. Lorem ipsum dolor sit amet consectetur adipisicing elit. Nesciunt labore nobis vel. Quisquam error fuga cumque dolore corporis? Exercitationem temporibus aut vero libero omnis explicabo harum alias! Incidunt, rem quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quasi unde consequuntur, error cum voluptatum eius a consectetur doloremque voluptas rem nam minima at praesentium hic eveniet minus iusto, amet quia!</a></p>
 		</div>
 	</div>
+	<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="/img/sponsor-block/c-sponsor-block-thumb.jpg" class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
 </aside>

--- a/assets/scss/6-components/sponsor-block/sponsor-block.html
+++ b/assets/scss/6-components/sponsor-block/sponsor-block.html
@@ -1,11 +1,87 @@
-<aside class="c-sponsor-block has-bg-white-off">
-	<div class="c-sponsor-block__text">
-		<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid Post</strong></span>
-		<div class="c-sponsor-block__main">
-			<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">TX Company 1234</h4>
-			<h3 class="c-sponsor-block__headline t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur adipisicing elit</a></h3>
-			<p class="c-sponsor-block__desc t-lh-m"><a href="#" class="has-text-black-off">Lorem ipsum, dolor sit amet consectetur adipisicing elit. Cumque, obcaecati suscipit! Ducimus soluta magnam ratione ullam eius repellat beatae tempora, quo ipsam alias porro voluptas a temporibus rerum maxime nisi. Lorem ipsum dolor sit amet consectetur adipisicing elit. Nesciunt labore nobis vel. Quisquam error fuga cumque dolore corporis? Exercitationem temporibus aut vero libero omnis explicabo harum alias! Incidunt, rem quos. Lorem ipsum dolor sit amet consectetur adipisicing elit. Quasi unde consequuntur, error cum voluptatum eius a consectetur doloremque voluptas rem nam minima at praesentium hic eveniet minus iusto, amet quia!</a></p>
+<div class="c-fluid-ad">
+	<aside class="c-sponsor-block">
+		<div class="c-sponsor-block__text">
+			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
+					Post</strong></span>
+			<div class="c-sponsor-block__main">
+				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">WGU TEXAS</h4>
+				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
+						class="has-text-black-off">Expanded broadband access lifts limits on human potential</a></h3>
+				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">With expanded broadband access you
+						reap what you sow – a smarter, healthier, more prosperous Texas.</a></p>
+			</div>
 		</div>
-	</div>
-	<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="/img/sponsor-block/c-sponsor-block-thumb.jpg" class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
-</aside>
+		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img
+				src="https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDnn6nRXhABGAEyCP4dyvqQGOGJ"
+				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
+	</aside>
+</div>
+
+<div class="c-fluid-ad">
+	<aside class="c-sponsor-block">
+		<div class="c-sponsor-block__text">
+			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
+					Post</strong></span>
+			<div class="c-sponsor-block__main">
+				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">HOGG FOUNDATION FOR MENTAL HEALTH</h4>
+				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
+						class="has-text-black-off">For World Mental Health Day, take 40 seconds</a></h3>
+				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Forty seconds is enough time to
+						make a difference that could save a life. It can also be the pivot point for a new national consensus that
+						makes our communities happier, healthier, and more equal.</a></p>
+			</div>
+		</div>
+		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img
+				src="https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKCn5IDkSBABGAEyCKzHvMxYuF6R"
+				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
+	</aside>
+</div>
+
+
+
+<div class="c-fluid-ad">
+	<aside class="c-sponsor-block">
+		<div class="c-sponsor-block__text">
+			<span class="c-sponsor-block__label t-uppercase t-lsp-b has-text-gray-dark t-size-xs has-xxs-btm-marg"><strong>Paid
+					Post</strong></span>
+			<div class="c-sponsor-block__main">
+				<h4 class="c-sponsor-block__sponsor has-text-sponsor t-uppercase t-lsp-m t-size-xs has-xxs-btm-marg">AUSTIN
+					COMMUNITY FOUNDATION</h4>
+				<h3 class="c-sponsor-block__headline c-sponsor-block__static-text t-links-underlined-hover t-lh-s has-xxs-btm-marg"><a href="#"
+						class="has-text-black-off">2020 Census: Billions are at stake</a></h3>
+				<p class="c-sponsor-block__desc c-sponsor-block__static-text t-lh-m"><a href="#" class="has-text-black-off">Overcoming the challenges facing
+						the 2020 Census will not be easy. All Texans have a role to play in ensuring an accurate count.</a></p>
+			</div>
+		</div>
+		<a href="#" class="c-sponsor-block__image-wrap l-display-block"><img src="
+	https://tpc.googlesyndication.com/pagead/imgad?id=CICAgKDn39r8KRABGAEyCGeabWxetsEq"
+				class="l-width-full c-sponsor-block__image" alt="Texas bluebonnets" /></a>
+	</aside>
+</div>
+
+
+
+
+
+
+<script>
+	const blocks = document.querySelectorAll('aside');
+	let timer = 1000;
+	blocks.forEach(block => {
+		timer = timer + 1000;
+		setTimeout(() => {
+			block.style.opacity = 1;
+		}, timer);
+	});
+	// var onresize = function() {
+	// 	console.log('=================');
+	// 	blocks.forEach(block => {
+	// 		const title = block.querySelector('h3 a').textContent;
+	// 		console.log(`${title}: ${block.clientHeight}`);
+	// 	});
+	// }
+	// window.addEventListener("resize", onresize);
+</script>
+
+
+


### PR DESCRIPTION
#### What's this PR do?

Adds some 🗜clamping to dynamic text blocks in the sponsor block component and a height wrapper to use on the /texastribune side of this ad implementation.
 
##### Classes added (if any)
- c-ad-fluid

#### Why are we doing this? How does it help us?

Lazy ads work best with predictable height. This allows the native ad implementation to have that predictability despite also needing variable lengths of text.

#### How should this be manually tested?
`yarn dev`

See:
- [c-ad-fluid](http://localhost:3000/pages/components/c-ad-fluid/raw-preview.html)
- [c-sponsor-block](http://localhost:3000/pages/components/c-sponsor-block/raw-preview.html)

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Not really, but it does require manually updating the [native ad code] here(https://admanager.google.com/5805113#creatives/custom_native_style/detail/styleid=259910).


#### TODOs / next steps:

* [x] *Update GAM to use new styles and ensure it outputs nicely on the site (with/without) lazy loading*
