### PR TITLE
Align event block buttons to bottom of container and cta spacing fixes

### DIFF
--- a/assets/scss/6-components/block-grid/_block-grid.scss
+++ b/assets/scss/6-components/block-grid/_block-grid.scss
@@ -9,14 +9,15 @@
 //
 // Styleguide 6.1.3
 .c-block-grid {
-  @include col-gap($size-s);
   @include row-gap($size-xxl);
   display: grid;
 
   @include mq($from: bp-m) {
+    @include col-gap($size-xxl);
     grid-template-columns: repeat(auto-fit, minmax(px-to-rem(300px), 1fr));
 
     &--min-100 {
+      @include col-gap($size-s);
       grid-template-columns: repeat(auto-fit, minmax(px-to-rem(100px), 1fr));
     }
   }

--- a/assets/scss/6-components/event-block/_event-block.scss
+++ b/assets/scss/6-components/event-block/_event-block.scss
@@ -7,9 +7,9 @@
 //
 // Styleguide 6.1.3
 .c-event-block {
-  position: relative;
   display: grid;
   grid-template-rows: auto 1fr;
+  position: relative;
 
   &__tag {
     position: absolute;

--- a/assets/scss/6-components/event-block/_event-block.scss
+++ b/assets/scss/6-components/event-block/_event-block.scss
@@ -8,6 +8,8 @@
 // Styleguide 6.1.3
 .c-event-block {
   position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr;
 
   &__tag {
     position: absolute;
@@ -22,6 +24,8 @@
   }
 
   &__content {
+    display: grid;
+    grid-template-rows: auto 1fr;
     padding-top: $size-tiny;
   }
 
@@ -30,6 +34,7 @@
       &--overlay {
         background: linear-gradient(rgba(0,0,0,0) -100%,#000);
         color: #fff;
+        grid-template-rows: 1fr;
         position: absolute;
         left: 0;
         bottom: 0;

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -38,7 +38,7 @@
   Event block with text and links always below the image.
   Accomplished by leaving off the `--overlay` modifier.
 -->
-<div class="c-event-block" aria-label="The Texas Tribune Festival" style="max-width: 300px;">
+<div class="c-event-block has-giant-btm-marg" aria-label="The Texas Tribune Festival" style="max-width: 300px;">
   <figure>
     <a href="#" class="l-display-block">
       <img class="l-display-block l-width-full" src="/img/event-block/c-event-block-thumb.jpg" alt="Attendees of The Texas Tribune Festival in Moody Theater"/>
@@ -65,6 +65,72 @@
       <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
         Watch
       </a>
+    </div>
+  </div>
+</div>
+
+<!--
+  Event block in context of grid
+-->
+<div class="c-block-grid">
+  <div class="c-event-block" aria-label="The Texas Tribune Festival">
+    <figure>
+      <a href="#" class="l-display-block">
+        <img class="l-display-block l-width-full" src="/img/event-block/c-event-block-thumb.jpg" alt="Attendees of The Texas Tribune Festival in Moody Theater"/>
+      </a>
+    </figure>
+    <time aria-hidden="true" class="c-event-block__tag l-display-ib has-bg-black-off t-uppercase t-lsp-b t-align-center t-weight-bold">
+      <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
+      <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
+    </time>
+    <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
+      <div class="c-cta-block__msg t-size-s">
+        <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
+          <a href="#" tabindex="-1">The Texas Tribune Festival</a>
+        </h3>
+        <p class="t-uppercase t-lsp-b t-size-xs">
+          <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+        </p>
+        <p class="is-sr-only">Sept. 26</p>
+      </div>
+      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-bottom-self">
+        <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+          Attend
+        </a>
+        <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+          Watch
+        </a>
+      </div>
+    </div>
+  </div>
+  <div class="c-event-block" aria-label="The Texas Tribune Festival">
+    <figure>
+      <a href="#" class="l-display-block">
+        <img class="l-display-block l-width-full" src="/img/event-block/c-event-block-thumb.jpg" alt="Attendees of The Texas Tribune Festival in Moody Theater"/>
+      </a>
+    </figure>
+    <time aria-hidden="true" class="c-event-block__tag l-display-ib has-bg-black-off t-uppercase t-lsp-b t-align-center t-weight-bold">
+      <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
+      <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
+    </time>
+    <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
+      <div class="c-cta-block__msg t-size-s">
+        <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
+          <a href="#" tabindex="-1">Some other headline, but more characters to show how buttons should align with any headline. The trick is to add l-align-bottom-self to the buttons.</a>
+        </h3>
+        <p class="t-uppercase t-lsp-b t-size-xs">
+          <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+        </p>
+        <p class="is-sr-only">Sept. 26</p>
+      </div>
+      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-bottom-self">
+        <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+          Attend
+        </a>
+        <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+          Watch
+        </a>
+      </div>
     </div>
   </div>
 </div>

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -93,7 +93,7 @@
         </p>
         <p class="is-sr-only">Sept. 26</p>
       </div>
-      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-bottom-self">
+      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-end-self">
         <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
           Attend
         </a>
@@ -116,14 +116,14 @@
     <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
       <div class="c-cta-block__msg t-size-s">
         <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
-          <a href="#" tabindex="-1">Some other headline, but more characters to show how buttons should align with any headline. The trick is to add l-align-bottom-self to the buttons.</a>
+          <a href="#" tabindex="-1">Some other headline, but more characters to show how buttons should align with any headline. The trick is to add l-align-end-self to the buttons.</a>
         </h3>
         <p class="t-uppercase t-lsp-b t-size-xs">
           <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
         </p>
         <p class="is-sr-only">Sept. 26</p>
       </div>
-      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-bottom-self">
+      <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-end-self">
         <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
           Attend
         </a>

--- a/assets/scss/7-layout/_align.scss
+++ b/assets/scss/7-layout/_align.scss
@@ -5,7 +5,7 @@
 // l-align-center-x - Uses auto side margin for **horizontal** center
 // l-align-center-y - Absolutely positioned for vertical **vertical** center
 // l-align-center-self - Used on children of flex or grid parent for **vertical** center
-// l-align-bottom-self - Used on children of flex or grid parent for forcing **bottom** alignment
+// l-align-end-self - Used on children of flex or grid parent for forcing **bottom** alignment
 // l-align-center-children - Apply to parent to center children. Centers x and y.
 //
 // Markup: 7-layout/align.html
@@ -31,7 +31,7 @@
   align-self: center;
 }
 // apply to an item with a flex or grid parent
-.l-align-bottom-self {
+.l-align-end-self {
   align-self: end;
 }
 

--- a/assets/scss/7-layout/_align.scss
+++ b/assets/scss/7-layout/_align.scss
@@ -4,7 +4,8 @@
 //
 // l-align-center-x - Uses auto side margin for **horizontal** center
 // l-align-center-y - Absolutely positioned for vertical **vertical** center
-// l-align-center-self - Used on children of flex parent for **vertical** center
+// l-align-center-self - Used on children of flex or grid parent for **vertical** center
+// l-align-bottom-self - Used on children of flex or grid parent for forcing **bottom** alignment
 // l-align-center-children - Apply to parent to center children. Centers x and y.
 //
 // Markup: 7-layout/align.html
@@ -25,9 +26,13 @@
   z-index: 1;
 }
 
-// apply to an item with a flex parent
+// apply to an item with a flex or grid parent
 .l-align-center-self {
   align-self: center;
+}
+// apply to an item with a flex or grid parent
+.l-align-bottom-self {
+  align-self: end;
 }
 
 .l-align-center-children {

--- a/assets/scss/7-layout/align.html
+++ b/assets/scss/7-layout/align.html
@@ -1,5 +1,5 @@
-<div style="border:2px solid black; width: 200px; height: 100px; position: relative; {% if className == 'l-align-center-self' %}display: flex{% endif %}" {% if className == 'l-align-center-children' %}class="{{className}}"{% endif %}>
+<div style="border:2px solid black; width: 200px; height: 100px; position: relative; {% if className == 'l-align-center-self' or className == 'l-align-end-self' %}display: flex{% endif %}" {% if className == 'l-align-center-children' %}class="{{className}}"{% endif %}>
   <div style="width: 50%;" class="has-padding has-bg-yellow {{className}}">Example</div>
 </div>
-{% if className == 'l-align-center-self' %}Parent is display: flex{% endif %}
+{% if className == 'l-align-center-self' or className == 'l-align-end-self'  %}Parent is display: flex{% endif %}
 {% if className == 'l-align-center-y' %}Parent is position: relative{% endif %}


### PR DESCRIPTION
#### What's this PR do?

Adds helper to align event block buttons.

##### Classes added (if any)
-  l-align-end-self 

#### Why are we doing this? How does it help us?

Less visually disruptive when event titles have varying lines of text

#### How should this be manually tested?
`yarn dev`

See: [c-event-block](http://localhost:3000/pages/components/c-event-block/raw-preview.html)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Should not.


#### TODOs / next steps:

* [ ] *Test out in rug branch*
