### PR TITLE
Update queso-tools to latest release

### DIFF
--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
   },
   "homepage": "https://github.com/texastribune/queso-ui#readme",
   "devDependencies": {
-    "@texastribune/queso-tools": "1.3.0",
+    "@texastribune/queso-tools": "^2.1.0",
     "axios": "^0.19.0",
     "browser-sync": "^2.26.3",
     "eslint": "^5.16.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,25 +179,20 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@texastribune/postcss-amp@^1.4.0":
-  version "1.4.0"
-  resolved "https://registry.yarnpkg.com/@texastribune/postcss-amp/-/postcss-amp-1.4.0.tgz#fb96d58eb5707cadf2ae9d10db697752697cae41"
-  integrity sha512-YqYumCnu/8L6awDD5GtSgAv3N8Wsgj7yU4Ipwhqdld4Sw8b2yvoIXMupR4nre2A61JQAOMs+Li7ECkNH2iz40w==
-
-"@texastribune/queso-tools@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@texastribune/queso-tools/-/queso-tools-1.3.0.tgz#9e31c05f69538c4337d7d93097ac917ca47961a2"
-  integrity sha512-GQZ+SHuwSE7VbwYLQ4x4+vqaypmWUVZmaF7GvOqrVqAgws+J3GPSeci67abynAyw8G01jpQdg7bKsKRAFVDLug==
+"@texastribune/queso-tools@^2.1.0":
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/@texastribune/queso-tools/-/queso-tools-2.1.0.tgz#3c12d0d801d3841cb419169db5461dcfdd8f3d69"
+  integrity sha512-3qza46RD/Fiah6NWvK6ohcsajqLb2DaLxcpz++9urPjPFR5jjFtqP6iiTYeVJ7vq3sENpa410Zs2CEplN6mu1w==
   dependencies:
-    "@texastribune/postcss-amp" "^1.4.0"
     amphtml-validator "^1.0.23"
     autoprefixer "^9.6.0"
     clean-css "^4.2.1"
     fast-glob "^3.0.1"
     fs-extra "^8.0.1"
     node-sass "^4.12.0"
-    ora "^3.4.0"
+    ora "^4.0.2"
     postcss "^7.0.17"
+    postcss-amp "^2.0.0"
     svgo "^1.2.2"
     svgstore "^3.0.0-2"
 
@@ -1089,7 +1084,7 @@ cli-cursor@^3.1.0:
   dependencies:
     restore-cursor "^3.1.0"
 
-cli-spinners@^2.0.0, cli-spinners@^2.2.0:
+cli-spinners@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-spinners/-/cli-spinners-2.2.0.tgz#e8b988d9206c692302d8ee834e7a85c0144d8f77"
   integrity sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==
@@ -3586,7 +3581,6 @@ known-css-properties@^0.16.0:
 
 "kss@https://github.com/kss-node/kss-node":
   version "3.0.0-beta.25"
-  uid f79e1ffc624efbf28d8bd72a3352d5ad85edfdd2
   resolved "https://github.com/kss-node/kss-node#f79e1ffc624efbf28d8bd72a3352d5ad85edfdd2"
   dependencies:
     bluebird "^3.5.4"
@@ -4689,19 +4683,7 @@ optionator@^0.8.2:
     type-check "~0.3.2"
     wordwrap "~1.0.0"
 
-ora@^3.4.0:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/ora/-/ora-3.4.0.tgz#bf0752491059a3ef3ed4c85097531de9fdbcd318"
-  integrity sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==
-  dependencies:
-    chalk "^2.4.2"
-    cli-cursor "^2.1.0"
-    cli-spinners "^2.0.0"
-    log-symbols "^2.2.0"
-    strip-ansi "^5.2.0"
-    wcwidth "^1.0.1"
-
-ora@^4.0.1:
+ora@^4.0.1, ora@^4.0.2:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/ora/-/ora-4.0.3.tgz#752a1b7b4be4825546a7a3d59256fa523b6b6d05"
   integrity sha512-fnDebVFyz309A73cqCipVL1fBZewq4vwgSHfxh43vVy31mbyoQ8sCH3Oeaog/owYOs/lLlGVPCISQonTneg6Pg==
@@ -5070,6 +5052,11 @@ posix-character-classes@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/posix-character-classes/-/posix-character-classes-0.1.1.tgz#01eac0fe3b5af71a2a6c02feabb8c1fef7e00eab"
   integrity sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
+postcss-amp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/postcss-amp/-/postcss-amp-2.0.0.tgz#d6384db3f9b05257e5e4e20027a2ad29fdf4b199"
+  integrity sha512-Irp3kPmOSv305LoSqMqm2ENNFVNGWvC/OSx2F/Snn2kEw4nDwMc0Gc6TSiUA1fjh7e1bdfRxnw4/1rp7RZRwCw==
 
 postcss-html@^0.36.0:
   version "0.36.0"


### PR DESCRIPTION
#### What's this PR do?
Bumps up to the latest queso-tools dependency and logging updates

#### Why are we doing this? How does it help us?

Just keeps our dependencies from falling behind.

#### How should this be manually tested?
`yarn`
`yarn dev`

**This only pertains to the build; no release needed**