### PR TITLE
Add color swatch contrast display

### DIFF
--- a/docs/config/tasks/style-doc.js
+++ b/docs/config/tasks/style-doc.js
@@ -10,6 +10,11 @@ const fs = require('fs');
 const ora = require('ora');
 const kss = require('kss');
 const md = require('markdown-it')({ html: true });
+const {
+  passesWcagAaLargeText,
+  passesWcagAa,
+  passesWcagAaa,
+} = require('passes-wcag');
 
 // internal
 const { slugify, stripTags } = require('./utils');
@@ -91,6 +96,15 @@ const processSection = (section, dir) => {
     };
   });
 
+  // check colors
+  const colors = section.colors.map(color => {
+    return {
+      ...color,
+      aa: passesWcagAa(color.color, '#fff'),
+      aaLargeText: passesWcagAaLargeText(color.color, '#fff'),
+      aaa: passesWcagAaa(color.color, '#fff'),
+    };
+  });
   const context = {
     ...section,
     slug,
@@ -108,6 +122,7 @@ const processSection = (section, dir) => {
     group,
     orderNumber,
     modifiers,
+    colors,
   };
 
   return context;

--- a/docs/src/macros/color-swatch.html
+++ b/docs/src/macros/color-swatch.html
@@ -1,11 +1,17 @@
-{% macro colorSwatch(name, color, description) %}
+{% macro colorSwatch(color) %}
 <div class="card">
-    <div class="section has-text-centered" style="background-color: {{ color }}"><code>{{ color }}</code></div>
+    <div class="section has-text-centered" style="background-color: {{ color.color }}"><code>{{ color.color }}</code></div>
     <div class="card-content">
-        <div class="title is-6">{{ name }}</div>
+        <div class="title is-6">{{ color.name }}</div>
         <p class="subtitle is-6">
-            {{ description | safe }}
+            {{ color.description | safe }}
         </p>
+        <ul>
+            <li><div class="ds-mini-swatch" aria-hidden="true" style="color: {{ color.color }}"></div></li>
+            <li class="ds-half-cols"><span>AA:</span><span>{% if color.aa %}✅{% else %}🚩{% endif %}</span></li>
+            <li class="ds-half-cols"><span>AAA:</span><span>{% if color.aaa %}✅{% else %}🚩{% endif %}</span></li>
+            <li class="ds-half-cols"><span>AA lg text:</span><span>{% if color.aaLargeText %}✅{% else %}🚩{% endif %}</span></li>
+        </ul>
     </div>
 </div>
 {% endmacro %}

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -83,7 +83,7 @@
               <div class="columns is-multiline">
                 {% for color in item.colors %}
                 <div class="column is-3">
-                  {{ colorSwatch(color.name, color.color, color.description) }}
+                  {{ colorSwatch(color) }}
                 </div>
                 {% endfor %}
               </div>

--- a/docs/src/scss/ds.scss
+++ b/docs/src/scss/ds.scss
@@ -9,7 +9,7 @@
 .ds-stick-it {
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 3;
 }
 
 .ds-breathe {
@@ -200,5 +200,37 @@ h6 {
     position: absolute;
     z-index: 2;
   }
-  
+
+}
+
+.ds-half-cols {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+}
+
+.ds-mini-swatch {
+  height: 25px;
+  margin-bottom: 1rem;
+  position: relative;
+  width: 25px;
+
+  &:before,
+  &:after {
+    content: '';
+    background-color: currentColor;
+    box-shadow: 0 2px 3px 0 rgba(0,0,0,.1),inset 0 0 0 1px rgba(0,0,0,.1);
+    left: 0px;
+    height: 100%;
+    position: absolute;
+    top: 0;
+    width: 100%;
+    z-index: 2;
+  }
+
+  &:before {
+    background-color: #fff;
+    top: 10px;
+    left: 10px;
+    z-index: 1;
+  }
 }

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "np": "^5.0.3",
     "nunjucks": "^3.1.7",
     "ora": "^4.0.1",
+    "passes-wcag": "^0.2.1",
     "prettier": "1.19.1",
     "purgecss": "^1.3.0",
     "purgecss-from-html": "^1.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1190,6 +1190,11 @@ color-convert@^2.0.1:
   dependencies:
     color-name "~1.1.4"
 
+color-convert@~0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/color-convert/-/color-convert-0.5.3.tgz#bdb6c69ce660fadffe0b0007cc447e1b9f7282bd"
+  integrity sha1-vbbGnOZg+t/+CwAHzER+G59ygr0=
+
 color-name@1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
@@ -2475,6 +2480,20 @@ get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-contrast-ratio@0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/get-contrast-ratio/-/get-contrast-ratio-0.2.1.tgz#3f8e2a9610df2fb55fc2004bfce002ff0aa25c0a"
+  integrity sha512-lNIpmDIoxlVJsEQ5G/XCxH2YiiXH0ukOZ0ASvPp9ku2f+2AOYG5OXQ9cLgc9p3lNom5gy8JLkfSzi8fZN9LdKg==
+  dependencies:
+    get-relative-luminance "0.3.1"
+
+get-relative-luminance@0.3.1:
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/get-relative-luminance/-/get-relative-luminance-0.3.1.tgz#f86b722194f87f23c9d4df9075e066329001907f"
+  integrity sha512-nLEJhDAPC4anQlFhBxt8lHRwxs5OvOxmN0mHCxOCFDtzy0x5cXTMKNKUycpulsAw1zNOtz6GIRcIaVMcUUcU7Q==
+  dependencies:
+    parse-color "1.0.0"
 
 get-stdin@^4.0.1:
   version "4.0.1"
@@ -4836,6 +4855,13 @@ parent-module@^1.0.0:
   dependencies:
     callsites "^3.0.0"
 
+parse-color@1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/parse-color/-/parse-color-1.0.0.tgz#7b748b95a83f03f16a94f535e52d7f3d94658619"
+  integrity sha1-e3SLlag/A/FqlPU15S1/PZRlhhk=
+  dependencies:
+    color-convert "~0.5.0"
+
 parse-entities@^1.0.2, parse-entities@^1.1.0:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/parse-entities/-/parse-entities-1.2.2.tgz#c31bf0f653b6661354f8973559cb86dd1d5edf50"
@@ -4908,6 +4934,13 @@ pascalcase@^0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/pascalcase/-/pascalcase-0.1.1.tgz#b363e55e8006ca6fe21784d2db22bd15d7917f14"
   integrity sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
+passes-wcag@^0.2.1:
+  version "0.2.1"
+  resolved "https://registry.yarnpkg.com/passes-wcag/-/passes-wcag-0.2.1.tgz#29634997d277668c4265e8fc82b4146c16fa98af"
+  integrity sha512-fUly3MR8Rp94IIK0M5DC3077Mwfxr6up8nREgKXw6UjSfF47RN9Ic7NIL2xOYiHXZbkko5xvyYeA+9rjOUUzLg==
+  dependencies:
+    get-contrast-ratio "0.2.1"
 
 path-dirname@^1.0.0:
   version "1.0.2"


### PR DESCRIPTION
#### What's this PR do?

Adds a little visual to aid in discussing color contrast ratios

#### Why are we doing this? How does it help us?

Quick checks on colors

#### How should this be manually tested?
`yarn dev`

See: [Swatch set - Branding](http://localhost:3000/pages/settings/index.html#swatch-set-branding)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope, just a docs enhancement


#### TODOs / next steps:

* [ ] *your TODO here*
