### PR TITLE
Add new border helpers + CTA button layout & t-byline updates

### DIFF
--- a/assets/scss/5-typography/_byline.scss
+++ b/assets/scss/5-typography/_byline.scss
@@ -6,7 +6,7 @@
 // - `t-uppercase`
 // - `t-lsp-m`
 // - `t-size-xs` (varies with context)
-// - `has-text-gray`
+// - `has-text-gray-dark`
 //
 //
 // Markup: 5-typography/byline.html
@@ -16,6 +16,6 @@
 //
 .t-byline {
   &__item {
-    padding-right: $size-b;
+    margin-right: $size-b;
   }
 }

--- a/assets/scss/5-typography/byline.html
+++ b/assets/scss/5-typography/byline.html
@@ -1,4 +1,4 @@
-<p class="t-byline t-links t-uppercase t-lsp-m t-size-xs has-text-gray">
+<p class="t-byline t-links t-uppercase t-lsp-m t-size-xs has-text-gray-dark">
   <span class="t-byline__item l-display-ib">by <a href="/about/staff/patrick-svitek/">Patrick Svitek</a></span>
   <time class="t-byline__item l-display-ib" datetime="2019-07-16 14:54:39.929-0400">July 16, 2019</time>
   <time class="t-byline__item l-display-ib">16 hours ago</time>

--- a/assets/scss/6-components/ad-fluid/_ad-fluid.scss
+++ b/assets/scss/6-components/ad-fluid/_ad-fluid.scss
@@ -8,8 +8,6 @@
 
 
 .c-ad-fluid {
-  border-top: 5px solid $color-sponsor;
-  border-bottom: 2px solid $color-sponsor;
   height: 400px;
 
   @include mq($from: bp-xs) {

--- a/assets/scss/6-components/ad-fluid/ad-fluid.html
+++ b/assets/scss/6-components/ad-fluid/ad-fluid.html
@@ -1,3 +1,3 @@
-<div class="c-ad-fluid has-bg-white-off">
-  <div style="display: grid; height: 100%; padding: 20px;"><div style="border: 1px dotted #000; padding: 20px;">Native ad goes here</div></div>
+<div class="c-ad-fluid has-styled-border has-text-sponsor has-bg-white-off">
+  <div style="display: grid; height: 100%; padding: 20px;" class="has-text-black-off"><div style="border: 1px dotted #000; padding: 20px;">Native ad goes here</div></div>
 </div>

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -8,7 +8,6 @@
 // .c-button--xs - Two steps down from default
 // .c-button--circle - Circular button (experimentally used for back to top)
 // .c-button--outline - Hover effect of outline (used on social)
-// .c-button--round - For the most part, buttons associated with revenue are rounded.
 //
 // Markup: 6-components/button/button.html
 //
@@ -94,10 +93,6 @@
     padding-bottom: 0;
     height: 26px;
     line-height: 26px;
-  }
-
-  &--round {
-    border-radius: $border-radius-l;
   }
 }
 

--- a/assets/scss/6-components/cta-block/_cta-block.scss
+++ b/assets/scss/6-components/cta-block/_cta-block.scss
@@ -1,7 +1,8 @@
 // CTA block (c-cta-block)
 //
-// Call to action with messaging and buttons. The window size determines the layout. **This would be a great use case for container queries.**
+// Call to action with messaging and buttons. The window size determines the layout. **This would be a great use case for container queries.** {{isWide}}
 //
+// .c-cta-block--horiz-from-bp-m - Container becomes two columns on wide screens. Fits a wider space.
 //
 // Markup: 6-components/cta-block/cta-block.html
 //
@@ -11,55 +12,43 @@ $cta-block-min-col: px-to-rem(130px);
 $cta-block-btn-height: px-to-rem(29px);
 
 .c-cta-block {
-  border: 1px solid $color-gray-light;
-  border-radius: $border-radius-b;
-
-  &--no-border {
-    border-width: 0;
-    border-radius: 0;
-  }
+  @include row-gap($size-s);
+  display: grid;
+  grid-template-columns: 1fr;
 
   &__btns {
     @include gap($size-xxs);
     display: grid;
     grid-auto-rows: $cta-block-btn-height;
-    margin-top: $size-s;
 
     // four buttons, all in a row
     &--4 {
       grid-template-columns: repeat(4, 1fr);
-
-      // buttons should become 2x2 on wide screens
-      &-stack-from-m {
-        grid-template-columns: repeat(4, 1fr);
-        @include mq($from: bp-m) {
-          grid-template-columns: repeat(2, 1fr);
-          margin-top: 0;
-        }
-      }
     }
 
     // two buttons, side by side
     &--2 {
       grid-template-columns: repeat(2, 1fr);
+    }
 
+    @include mq($from: bp-m) {
       // buttons should become 1x1 on wide screens
-      &-stack-from-m {
+      &--1-from-bp-m {
+        grid-template-columns: 1fr;
+      }
+      // buttons should become 2x2 on wide screens
+      &--2-from-bp-m {
         grid-template-columns: repeat(2, 1fr);
-        @include mq($from: bp-m) {
-          grid-template-columns: 1fr;
-          margin-top: 0;
-        }
       }
     }
+
   }
 
   @include mq($from: bp-m) {
     // container should become two columns on wide screens
-    &--horiz-from-m {
+    &--horiz-from-bp-m {
       @include gap($size-l);
       align-items: center;
-      display: grid;
       grid-template-columns: 1fr $cta-block-min-col;
     }
   }

--- a/assets/scss/6-components/cta-block/cta-block.html
+++ b/assets/scss/6-components/cta-block/cta-block.html
@@ -1,39 +1,83 @@
-<!-- Social Follow CTA -->
-<div class="c-cta-block c-cta-block--horiz-from-m has-xl-padding has-giant-btm-marg">
-  <div class="c-cta-block__msg t-size-s">
-    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-xxs-btm-marg">Stay in the loop</h4>
-    <p class="has-xxs-btm-marg t-size-m"><strong>The next time news breaks, hear about it first.</strong></p>
-    <p class="has-text-gray t-links-underlined">Follow The Texas Tribune on <a href="#">Facebook</a> and <a href="#">Twitter</a>.</p>
+{% if className == 'c-cta-block--horiz-from-bp-m' %}
+  <!-- Social Follow CTA -->
+  <div class="c-cta-block {{ className }} is-rounded-b has-border has-xl-padding has-giant-btm-marg">
+    <div class="c-cta-block__msg t-size-s">
+      <h4 class="t-uppercase t-lsp-m t-lh-b has-text-teal has-xxs-btm-marg">Stay in the loop</h4>
+      <p class="has-xxs-btm-marg t-size-m"><strong>The next time news breaks, hear about it first.</strong></p>
+      <p class="has-text-gray t-links-underlined">Follow The Texas Tribune on <a href="#">Facebook</a> and <a href="#">Twitter</a>.</p>
+    </div>
+    <div class="c-cta-block__btns c-cta-block__btns--2 c-cta-block__btns--1-from-bp-m t-align-center">
+      <a class="c-button has-bg-facebook l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
+        <span class="c-button__inner t-size-xxs">Facebook</span>
+      </a>
+      <a class="c-button has-bg-twitter l-align-center-children has-reset-padding" href="#" aria-label="Share on Twitter">
+        <span class="c-button__inner t-size-xxs">Twitter</span>
+      </a>
+    </div>
   </div>
-  <div class="c-cta-block__btns c-cta-block__btns--2-stack-from-m t-align-center">
-    <a class="c-button has-bg-facebook l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
-      <span class="c-button__inner t-size-xxs">Facebook</span>
-    </a>
-    <a class="c-button has-bg-twitter l-align-center-children has-reset-padding" href="#" aria-label="Share on Twitter">
-      <span class="c-button__inner t-size-xxs">Twitter</span>
-    </a>
-  </div>
-</div>
 
-<!-- Membership CTA -->
-<div class="c-cta-block c-cta-block--horiz-from-m has-xl-padding">
-  <div class="c-cta-block__msg t-size-s">
-    <h4 class="t-uppercase t-uppercase--extra-wide t-space-b has-text-teal has-xxs-btm-marg"><strong>Join our nonprofit newsroom</strong></h4>
-    <p class="has-xxs-btm-marg t-size-m"><strong>Support our voting rights coverage by becoming a Texas Tribune member today.</strong></p>
-    <p class="has-text-gray t-links-underlined">Choose an amount to give or <a href="#" class="l-display-ib">learn more about membership</a>.</p>
+  <!-- Membership CTA -->
+  <div class="c-cta-block {{ className }} is-rounded-b has-border has-xl-padding has-giant-btm-marg">
+    <div class="c-cta-block__msg t-size-s">
+      <h4 class="t-uppercase t-lsp-m t-lh-b has-text-teal has-xxs-btm-marg"><strong>Join our nonprofit newsroom</strong></h4>
+      <p class="has-xxs-btm-marg t-size-m"><strong>Support our voting rights coverage by becoming a Texas Tribune member today.</strong></p>
+      <p class="has-text-gray t-links-underlined">Choose an amount to give or <a href="#" class="l-display-ib">learn more about membership</a>.</p>
+    </div>
+    <div class="c-cta-block__btns c-cta-block__btns--4 c-cta-block__btns--2-from-bp-m t-align-center t-size-s">
+      <a class="c-button is-rounded-l has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
+        <span class="c-button__inner has-text-black">$35</span>
+      </a>
+      <a class="c-button is-rounded-l has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
+        <span class="c-button__inner has-text-black">$75</span>
+      </a>
+      <a class="c-button is-rounded-l has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
+        <span class="c-button__inner has-text-black">$150</span>
+      </a>
+      <a class="c-button c-button--outline is-rounded-l has-bg-white has-text-yellow l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
+        <span class="c-button__inner has-text-black t-titlecase">Other</span>
+      </a>
+    </div>
   </div>
-  <div class="c-cta-block__btns c-cta-block__btns--4-stack-from-m t-align-center t-size-s">
-    <a class="c-button c-button--round has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
-      <span class="c-button__inner has-text-black">$35</span>
-    </a>
-    <a class="c-button c-button--round has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
-      <span class="c-button__inner has-text-black">$75</span>
-    </a>
-    <a class="c-button c-button--round has-bg-yellow has-text-black l-align-center-children has-reset-padding" href="#">
-      <span class="c-button__inner has-text-black">$150</span>
-    </a>
-    <a class="c-button c-button--outline c-button--round has-bg-white has-text-yellow l-align-center-children has-reset-padding" href="#" aria-label="Share on Facebook">
-      <span class="c-button__inner has-text-black t-titlecase">Other</span>
-    </a>
+
+  <!-- Overlay event CTA -->
+  <div class="c-cta-block {{ className }}">
+    <div class="c-cta-block__msg t-size-s">
+      <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-l">
+        <a href="#" tabindex="-1">The Texas Tribune Festival</a>
+      </h3>
+      <p class="t-uppercase t-lsp-b t-size-xs">
+        <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+      </p>
+      <p class="is-sr-only">Sept. 26</p>
+    </div>
+    <div class="c-cta-block__btns c-cta-block__btns--2 c-cta-block__btns--1-from-bp-m t-align-center">
+      <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+        Attend
+      </a>
+      <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+        Watch
+      </a>
+    </div>
   </div>
-</div>
+{% else %}
+  <!-- Minimal event block -->
+  <div class="c-cta-block">
+    <div class="c-cta-block__msg t-size-s">
+      <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
+        <a href="#" tabindex="-1">The Texas Tribune Festival</a>
+      </h3>
+      <p class="t-uppercase t-lsp-b t-size-xs">
+        <strong>Held in Austin | 7 p.m. - 10 p.m.</strong>
+      </p>
+      <p class="is-sr-only">Sept. 26</p>
+    </div>
+    <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center">
+      <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
+        Attend
+      </a>
+      <a class="c-button c-button--standard has-bg-gray-dark has-text-white l-align-center-children t-size-xs" href="#">
+        Watch
+      </a>
+    </div>
+  </div>
+{% endif %}

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -83,7 +83,7 @@
       <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
       <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
     </time>
-    <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
+    <div class="c-event-block__content c-cta-block l-width-full">
       <div class="c-cta-block__msg t-size-s">
         <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
           <a href="#" tabindex="-1">The Texas Tribune Festival</a>
@@ -113,7 +113,7 @@
       <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
       <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
     </time>
-    <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
+    <div class="c-event-block__content c-cta-block l-width-full">
       <div class="c-cta-block__msg t-size-s">
         <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
           <a href="#" tabindex="-1">Some other headline, but more characters to show how buttons should align with any headline. The trick is to add l-align-end-self to the buttons.</a>

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -13,7 +13,7 @@
     <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
     <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
   </time>
-  <div class="c-event-block__content c-event-block__content--overlay c-cta-block c-cta-block--horiz-from-m c-cta-block--no-border l-width-full">
+  <div class="c-event-block__content c-event-block__content--overlay c-cta-block c-cta-block--horiz-from-bp-m l-width-full">
     <div class="c-cta-block__msg t-size-s">
       <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-l">
         <a href="#" tabindex="-1">The Texas Tribune Festival</a>
@@ -23,7 +23,7 @@
       </p>
       <p class="is-sr-only">Sept. 26</p>
     </div>
-    <div class="c-cta-block__btns c-cta-block__btns--2-stack-from-m t-align-center">
+    <div class="c-cta-block__btns c-cta-block__btns--2 c-cta-block__btns--1-from-bp-m t-align-center">
       <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
         Attend
       </a>
@@ -48,7 +48,7 @@
     <div class="t-uppercase has-text-yellow t-size-xs t-lh-s">Sept.</div>
     <div class="c-event-block__day t-size-giant has-text-white t-lh-s">26</div>
   </time>
-  <div class="c-event-block__content c-cta-block c-cta-block--no-border l-width-full">
+  <div class="c-event-block__content c-cta-block">
     <div class="c-cta-block__msg t-size-s">
       <h3 aria-hidden="true" class="has-xxxs-btm-marg t-serif t-links-underlined-hover t-size-m">
         <a href="#" tabindex="-1">The Texas Tribune Festival</a>

--- a/assets/scss/6-components/widget/_widget.scss
+++ b/assets/scss/6-components/widget/_widget.scss
@@ -6,7 +6,5 @@
 //
 // Styleguide 6.1.3
 .c-widget {
-  border-top: 4px solid currentColor;
-  border-bottom: 2px solid currentColor;
   padding: $size-xxxs 0;
 }

--- a/assets/scss/6-components/widget/widget.html
+++ b/assets/scss/6-components/widget/widget.html
@@ -1,3 +1,3 @@
-<div class="c-widget">
+<div class="c-widget has-styled-border">
   <div class="has-bg-white-off has-padding">Sidebar item</div>
 </div>

--- a/assets/scss/utilities/_all.scss
+++ b/assets/scss/utilities/_all.scss
@@ -3,9 +3,11 @@
 // Helper overrides for various utilities. V2 will use prefixes of .l-, .has-, .is-
 //
 // Styleguide 8.0
+@import 'border';
 @import 'color-helpers';
 @import 'hidden';
 @import 'notch';
+@import 'rounded';
 @import 'shadows';
 @import 'spacing';
 @import 'vert-bar';

--- a/assets/scss/utilities/_border.scss
+++ b/assets/scss/utilities/_border.scss
@@ -1,0 +1,20 @@
+// Border (has-border)
+//
+// Helpers for borders. {{isHelper}}
+//
+// .has-border - This is our standard border color.
+// .has-styled-border - Uses `currentColor` to inherit a `border-color` from `color`. Can be coupled with the `has-text-<color>` helper. This border is a common pattern in sidebar blocks and ads.
+//
+// Markup: <div class="{{ className }} has-text-black has-padding">Bordered</div>
+//
+//
+// Styleguide 8.0.3
+//
+.has-border {
+  border: 1px solid $color-gray-light;
+}
+
+.has-styled-border {
+  border-top: 4px solid currentColor;
+  border-bottom: 2px solid currentColor;
+}

--- a/assets/scss/utilities/_rounded.scss
+++ b/assets/scss/utilities/_rounded.scss
@@ -1,0 +1,19 @@
+// Border Radius (is-rounded-<size>)
+//
+// For roundin' out those corners. {{isHelper}}
+//
+// .is-rounded-b - The base rounded measure `4px`
+// .is-rounded-l - More dramatic rounding of `40px`. (Used for pill buttons in donation CTAs.)
+//
+// Markup: <div class="{{ className }} has-bg-gray-light has-padding">Bordered</div>
+//
+//
+// Styleguide 8.0.3
+//
+.is-rounded-b {
+  border-radius: 4px;
+}
+
+.is-rounded-l {
+  border-radius: 40px;
+}


### PR DESCRIPTION
#### What's this PR do?

- Introduces some border helpers
- (Maybe?) simplifies all the CTA button variations
- Changes `t-byline` to use margin
- Makes `t-byline` example gray text meet the contrast ratio for AA

##### Classes added (if any)
- has-border
- has-styled-border
- is-rounded-b
- is-rounded-l

##### Classes removed (if any)
- c-button--round
- Also removes some declarations that the new helpers can accommodate instead.

----

#### Why are we doing this? How does it help us?

##### Border helpers
Give us the ability to create "the box" look on the fly.

##### `t-byline` adjustments
Margin instead of padding allows the rug author feed to use the `t-byline` helper in this version of a byline with underlined links
<img width="272" alt="Screen Shot 2019-11-14 at 9 08 58 AM" src="https://user-images.githubusercontent.com/2974713/68869227-7681ea80-06be-11ea-9ba4-46617ac371f5.png">


##### `c-cta-block__btns` adjustments
I thought this might make those modifiers a little more DRY (in terms of the CSS) and systematic. What do you think @AndrewGibson27? 
To highlight that change...
instead of:
```scss
  &__btns {
    @include gap($size-xxs);
    display: grid;
    grid-auto-rows: $cta-block-btn-height;
    margin-top: $size-s;

    // four buttons, all in a row
    &--4 {
      grid-template-columns: repeat(4, 1fr);

      // buttons should become 2x2 on wide screens
      &-stack-from-m {
        grid-template-columns: repeat(4, 1fr);
        @include mq($from: bp-m) {
          grid-template-columns: repeat(2, 1fr);
          margin-top: 0;
        }
      }
    }

    // two buttons, side by side
    &--2 {
      grid-template-columns: repeat(2, 1fr);

      // buttons should become 1x1 on wide screens
      &-stack-from-m {
        grid-template-columns: repeat(2, 1fr);
        @include mq($from: bp-m) {
          grid-template-columns: 1fr;
          margin-top: 0;
        }
      }
    }
  }
```
make `c-cta-block__btns--2-from-bp-m` and `c-cta-block__btns--1-from-bp-m` new modifers that you'd append when you want them.
```scss
  &__btns {
    @include gap($size-xxs);
    display: grid;
    grid-auto-rows: $cta-block-btn-height;

    // four buttons, all in a row
    &--4 {
      grid-template-columns: repeat(4, 1fr);
    }

    // two buttons, side by side
    &--2 {
      grid-template-columns: repeat(2, 1fr);
    }

    @include mq($from: bp-m) {
      // buttons should become 1x1 on wide screens
      &--1-from-bp-m {
        grid-template-columns: 1fr;
      }
      // buttons should become 2x2 on wide screens
      &--2-from-bp-m {
        grid-template-columns: repeat(2, 1fr);
      }
    }

  }
```
I figure on the CSS side, that's a little less repetitive. If you feel that adds complexity or messy HTML, I'm not married to that. We may have even discussed this already; sorry if that's the case!


----

#### How should this be manually tested?
`yarn dev`

The only real new parts here are the border helpers:
- [borders](http://localhost:3000/pages/utilities/index.html#border-has-border)
- [border-radius](http://localhost:3000/pages/utilities/index.html#border-radius-is-rounded-size)
How do we feel about those class names? Easy to remember? Scaleable?

----

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Yes. Steps to correct are noted below.

----

#### TODOs / next steps:

##### Border helpers
* [x] Change `c-button--round` => `is-rounded-l` [here](https://github.com/texastribune/texastribune/blob/master/snollygoster/content_management/plugins/promo/templates/cms_promo/includes/cta_membership_btns.html#L1)
* [x] Append `has-border` & `is-rounded-b` & `c-cta-block--horiz-from-bp-m` [here](https://github.com/texastribune/texastribune/blob/master/snollygoster/content_management/plugins/promo/templates/cms_promo/cta_base.html#L2)
* [ ] ~Append `is-rounded-b` [here](https://github.com/texastribune/texastribune/pull/3723/files#diff-226a77b1c84d4b12237c6043a79a682dR28)~ - @AndrewGibson27 will handle
* [ ] ~Remove `border-radius: 5px;` [here](https://github.com/texastribune/texastribune/pull/3723/files#diff-5b42c1450bc5e696b8538ef6fa939058R3) (Check with EY that 5px to 4px is fine)~ - @AndrewGibson27 will handle

##### `c-cta-block__btns` adjustments
* [x] Change `c-cta-block__btns--2-stack-from-m` => `c-cta-block__btns--2` & `c-cta-block__btns--1-from-bp-m` [here](https://github.com/texastribune/texastribune/blob/master/snollygoster/content_management/plugins/promo/templates/cms_promo/cta_social_follow.html#L11)
* [x] Change `c-cta-block__btns--4-stack-from-m` => `c-cta-block__btns--4` & `c-cta-block__btns--2-from-bp-m` [here](https://github.com/texastribune/texastribune/blob/master/snollygoster/content_management/plugins/promo/templates/cms_promo/cta_membership.html#L11)

##### `t-byline` adjustments (@AndrewGibson27 will handle)
* [ ] ~Change `c-reporters-list__author-link` => `t-byline__item` [here](https://github.com/texastribune/texastribune/pull/3723/files#diff-226a77b1c84d4b12237c6043a79a682dR56)~
* [ ] ~Remove `margin-right: 5px` [here](https://github.com/texastribune/texastribune/pull/3723/files#diff-5b42c1450bc5e696b8538ef6fa939058R7)~
* [ ] ~Append `t-byline` [here](https://github.com/texastribune/texastribune/pull/3723/files#diff-226a77b1c84d4b12237c6043a79a682dR53) (Doesn't do anything, but keeps byline markup consistent)~
* [ ] ~Change `byline__item` => `t-byline__item` [here](https://github.com/texastribune/texastribune/blob/ccab8b542c5635e3fea014fdce13becae8796263/snollygoster/tt_mailchimp/templates/newsletters/newsletter_detail.html#L34)~


