### PR TITLE
Revist the story block a11y implementation

### DIFF
--- a/assets/scss/6-components/story-block/_story-block.scss
+++ b/assets/scss/6-components/story-block/_story-block.scss
@@ -16,7 +16,6 @@
   @include gap;
   display: grid;
   grid-template-columns: 5fr 7fr;
-  grid-auto-rows: min-content;
   grid-template-areas: 'image-wrap text';
 
   &__headline {

--- a/assets/scss/6-components/story-block/_story-block.scss
+++ b/assets/scss/6-components/story-block/_story-block.scss
@@ -16,9 +16,19 @@
   @include gap;
   display: grid;
   grid-template-columns: 5fr 7fr;
+  grid-auto-rows: min-content;
+  grid-template-areas: 'image-wrap text';
 
   &__headline {
     font-size: $size-s;
+  }
+
+  &__image-wrap {
+    grid-area: image-wrap;
+  }
+
+  &__text {
+    grid-area: text;
   }
 
   &--featured {
@@ -29,7 +39,7 @@
     &--stack-from-bp-m {
       @include gap($size-xxs);
       grid-template-columns: 1fr;
-      grid-auto-rows: min-content;
+      grid-template-areas: 'image-wrap' 'text';
     }
 
     &__headline {
@@ -41,19 +51,21 @@
     &--stack-from-bp-l {
       @include gap($size-xxs);
       grid-template-columns: 1fr;
-      grid-auto-rows: min-content;
+      grid-template-areas: 'image-wrap' 'text';
     }
   }
 
   @include mq($until: bp-m) {
     &--stack-until-bp-m {
       grid-template-columns: 1fr;
+      grid-template-areas: 'image-wrap' 'text';
     }
   }
 
   @include mq($until: bp-l) {
     &--stack-until-bp-l {
       grid-template-columns: 1fr;
+      grid-template-areas: 'image-wrap' 'text';
     }
   }
 }

--- a/assets/scss/6-components/story-block/story-block-alt.html
+++ b/assets/scss/6-components/story-block/story-block-alt.html
@@ -1,6 +1,6 @@
 <article class="c-story-block c-story-block--stack-from-bp-m">
   <div class="c-story-block__text">
-    <!-- headline -->
+    <!-- headline (h# tag will depend on context) -->
     <h3 class="t-size-s t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a class="has-text-black-off"><a href="#">The best and worst moments in Texas politics of 2019</a></h3>
   </div>
   <figure class="c-story-block__image-wrap l-display-block l-width-full">

--- a/assets/scss/6-components/story-block/story-block-alt.html
+++ b/assets/scss/6-components/story-block/story-block-alt.html
@@ -1,9 +1,9 @@
 <article class="c-story-block c-story-block--stack-from-bp-m">
-  <figure class="l-display-block l-width-full">
-    <a href="#"><img class="l-display-block l-width-full" src="/img/DEFAULT_LEAD_ART.jpg" alt="Story block alt tag"></a>
-  </figure>
-  <section>
+  <div class="c-story-block__text">
     <!-- headline -->
-    <h3 class="t-size-s t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg js-balance"><a class="has-text-black-off"><a href="#">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Facilis ea fuga ipsum doloremque porro voluptatem fugit.</a></h3>
-  </section>
+    <h3 class="t-size-s t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a class="has-text-black-off"><a href="#">The best and worst moments in Texas politics of 2019</a></h3>
+  </div>
+  <figure class="c-story-block__image-wrap l-display-block l-width-full">
+    <a href="#" tabindex="-1"><img class="l-display-block l-width-full" src="/img/DEFAULT_LEAD_ART.jpg" alt="Placeholder image of Texas Capitol dome and Texas Tribune branding"></a>
+  </figure>
 </article>

--- a/assets/scss/6-components/story-block/story-block.html
+++ b/assets/scss/6-components/story-block/story-block.html
@@ -1,14 +1,14 @@
 <article class="c-story-block {{ className }}">
-  <section class="c-story-block__text">
+  <div class="c-story-block__text">
     <!-- headline -->
-    <h3 class="c-story-block__headline t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a href="#" class="has-text-black-off">This is the headline</a></h3>
+    <h3 class="c-story-block__headline t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a href="#" class="has-text-black-off">The best and worst moments in Texas politics of 2019</a></h3>
     <!-- byline -->
     <p class="t-byline t-size-xs t-links t-uppercase t-lsp-m has-text-gray has-b-btm-marg">
       <span class="t-byline__item">by <a href="#">George Costanza</a> and <a href="#">Cosmo Kramer</a></span><time class="t-byline__item" datetime="Mon, 16 Sep 2019 05:00:00 -0500">Sept. 16, 2019</time>
     </p>
     <!-- summary -->
     <p class="t-serif t-links t-size-s is-hidden-until-bp-s">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Unde rem ipsum officia eum, iusto aliquam reprehenderit similique at vero dolores saepe nisi quas corporis voluptate suscipit explicabo, aspernatur consequuntur nihil. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias velit eaque at nemo! Natus voluptas debitis blanditiis velit rem aut aliquid delectus, voluptatem modi laborum excepturi doloremque dignissimos itaque. Id! <a class="t-uppercase t-size-xxs t-lsp-m t-sans l-display-ib" href="#">Full Story<span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#long-arrow-right"></use></svg></span></a></p>
-  </section>
+  </div>
   <figure class="c-story-block__image-wrap">
     <a href="#" tabindex="-1">
       <img class="l-display-block l-width-full" src="/img/DEFAULT_LEAD_ART.jpg" alt="Placeholder image of Texas Capitol dome and Texas Tribune branding">

--- a/assets/scss/6-components/story-block/story-block.html
+++ b/assets/scss/6-components/story-block/story-block.html
@@ -1,6 +1,6 @@
 <article class="c-story-block {{ className }}">
   <div class="c-story-block__text">
-    <!-- headline -->
+    <!-- headline (h# tag will depend on context) -->
     <h3 class="c-story-block__headline t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a href="#" class="has-text-black-off">The best and worst moments in Texas politics of 2019</a></h3>
     <!-- byline -->
     <p class="t-byline t-size-xs t-links t-uppercase t-lsp-m has-text-gray has-b-btm-marg">

--- a/assets/scss/6-components/story-block/story-block.html
+++ b/assets/scss/6-components/story-block/story-block.html
@@ -1,19 +1,19 @@
 <article class="c-story-block {{ className }}">
-  <figure class="l-display-block l-width-full">
-    <a href="#">
+  <section class="c-story-block__text">
+    <!-- headline -->
+    <h3 class="c-story-block__headline t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg"><a href="#" class="has-text-black-off">This is the headline</a></h3>
+    <!-- byline -->
+    <p class="t-byline t-size-xs t-links t-uppercase t-lsp-m has-text-gray has-b-btm-marg">
+      <span class="t-byline__item">by <a href="#">George Costanza</a> and <a href="#">Cosmo Kramer</a></span><time class="t-byline__item" datetime="Mon, 16 Sep 2019 05:00:00 -0500">Sept. 16, 2019</time>
+    </p>
+    <!-- summary -->
+    <p class="t-serif t-links t-size-s is-hidden-until-bp-s">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Unde rem ipsum officia eum, iusto aliquam reprehenderit similique at vero dolores saepe nisi quas corporis voluptate suscipit explicabo, aspernatur consequuntur nihil. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias velit eaque at nemo! Natus voluptas debitis blanditiis velit rem aut aliquid delectus, voluptatem modi laborum excepturi doloremque dignissimos itaque. Id! <a class="t-uppercase t-size-xxs t-lsp-m t-sans l-display-ib" href="#">Full Story<span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#long-arrow-right"></use></svg></span></a></p>
+  </section>
+  <figure class="c-story-block__image-wrap">
+    <a href="#" tabindex="-1">
       <img class="l-display-block l-width-full" src="/img/DEFAULT_LEAD_ART.jpg" alt="Placeholder image of Texas Capitol dome and Texas Tribune branding">
     </a>
     <figcaption class="c-caption c-caption--compact has-text-gray-dark l-display-block t-size-xxs">This is an image caption describing the image above. <span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span> <cite>Photographer Name for Company XYZ</cite>
     </figcaption>
   </figure>
-  <section>
-    <!-- headline -->
-    <h3 class="c-story-block__headline t-serif t-lh-s t-lsp-s t-links-underlined-hover has-xxxs-btm-marg js-balance"><a href="#" class="has-text-black-off">Lorem ipsum dolor sit amet consectetur, adipisicing elit. Facilis ea fuga ipsum doloremque porro voluptatem fugit.</a></h3>
-    <!-- byline -->
-    <p class="t-byline t-size-xs t-links t-uppercase t-lsp-m has-text-gray has-b-btm-marg">
-      <span class="t-byline__item">by <a href="#">George Costanza</a> and <a href="#">Cosmo Kramer</a></span><time class="t-byline__item" datetime="Mon, 16 Sep 2019 05:00:00 -0500" title="2019-09-16 05:00">Sept. 16, 2019</time>
-    </p>
-    <!-- summary -->
-    <p class="t-serif t-links t-size-s is-hidden-until-bp-s">Lorem ipsum dolor, sit amet consectetur adipisicing elit. Unde rem ipsum officia eum, iusto aliquam reprehenderit similique at vero dolores saepe nisi quas corporis voluptate suscipit explicabo, aspernatur consequuntur nihil. Lorem ipsum dolor sit amet, consectetur adipisicing elit. Alias velit eaque at nemo! Natus voluptas debitis blanditiis velit rem aut aliquid delectus, voluptatem modi laborum excepturi doloremque dignissimos itaque. Id! <a class="t-uppercase t-size-xxs t-lsp-m t-sans l-display-ib" href="#">Full Story<span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#long-arrow-right"></use></svg></span></a></p>
-  </section>
 </article>


### PR DESCRIPTION
#### What's this PR do?

- Forces the `<article>` label (the h3) to be first in the markup sequence and adjusts the CSS accordingly to have the image still display first on the page render.
- Removes tabbing on the extra image link

#### Why are we doing this? How does it help us?

- This guy [says to](https://css-tricks.com/how-to-section-your-html/#custom-header-id-6). It does make sense that the source order should match the hierarchy of the component.
THEN AGAIN 😩 - This bit from the [WCAG explanation](https://www.w3.org/TR/UNDERSTANDING-WCAG20/content-structure-separation-sequence.html) makes me question if this actually affects meaning and thus still applies here.
> Providing a particular linear order is only required where it affects meaning.


- The tabbing is a judgment call of mine based on how that story block will ultimately be repeated over and over. If I didn't use a mouse, I'd much rather just tab through the right side (text) links as opposed to tabbing through the mirrored link around the image as well. I considered removing on "full story ->" too, but ultimately kept that one.


#### How should this be manually tested?
`yarn dev`

See: [c-story-block](http://localhost:3000/pages/components/c-story-block/raw-preview.html)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope, this isn't used yet. But I need this visual order trickery for the readmores


#### TODOs / next steps:

* [ ] *your TODO here*
