### PR TITLE
Use h2 tags for in-story headers

### DIFF
--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -49,16 +49,17 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     list-style: disc;
   }
 
+  // h2s are a dropdown option in the CMS
+  // we hard-set the font size for this reason
+  > h2 {
+    font-size: $size-m;
+  }
+
   sub, sup {
     position: initial;
   }
 
   hr {
     margin: $size-xl auto;
-  }
-  // h3s are a dropdown option in the CMS
-  // we hard-set the font size for this reason
-  h3 {
-    font-size: $size-m;
   }
 }

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,32 +1,33 @@
-<section class="c-story-body has-l-btm-marg t-size-b story_body">
+<div class="c-story-body has-l-btm-marg t-size-b story_body">
   <p>Our editor outputs blocks of texts with paragraph tags. This parent class also accounts for descendant links, headings, horizontal rules, and lists.</p>
-  <h3>Horizontal Rules</h3>
+  
+  <h2>Horizontal Rules</h2>
   <p>Use a horizontal rule to break up content. A horizontal rule is displayed below.</p>
   <hr/>
   <p>The hr tag has built in top and bottom margin. We do this because it's normally used as a spacing element and the need for cushion is assumed.</p>
-  <h3>Ordered Lists</h3>
+  
+  <h2>Ordered Lists</h2>
   <p>Ordered lists are lists with numbers and need the special container and a list style treatment.</p>
   <ol>
     <li>This is the first item.</li>
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ol>
-  <h3>Unordered Lists</h3>
+  
+  <h2>Unordered Lists</h2>
   <p>Unordered lists are lists with bullets and also need the special container and a list style treatment. We globally remove bullets so lists within the c-story-body class we add them back via the ul tag.</p>
   <ul>
     <li>This is the first item.</li>
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ul>
-  <h3>Headings</h3>
-  <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h3. In the event someone were to open the source and add others, this is how they would display.</p>
-  <h2>Heading 2</h2>
-  <h3>Heading 3 - Default</h3>
-  <h4>Heading 4</h4>
-  <h5>Heading 5</h5>
-  <h6>Heading 6</h6>
-  <h3>Plugins</h3>
+  
+  <h2>Headings</h2>
+  <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h2.</p>
+  <h2>I am an example heading</h2>
+  
+  <h2>Plugins</h2>
   <p>Plugins are special and have their own rules for positioning. A div without the plugin class will still align with the story text, but any div prefixed with "plugin" will be excluded from the max-width and margin declaration the other elements adhere to.</p>
   <div class="plugin has-padding has-bg-gray-light">Example of plugin. Should be not be bound by container.</div>
   <div class="plugin-ad has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>
-</section>
+</div>


### PR DESCRIPTION
#### What's this PR do?
What the title says.

##### Classes added (if any)
I modified one rule: `.c-story-body h3` became `.c-story-body > h2`.

#### Why are we doing this? How does it help us?
So we don't skip heading levels in the `<article>`. And so in-plugin headers don't errantly pick up these styles.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
This change is non-breaking inside queso because no markup changes are required. There will be an accompanying `texastribune` PR that makes our editor use `h2` tags.