### PR TITLE
Add centering back to cta-block but not for event-block

### DIFF
--- a/assets/scss/6-components/cta-block/_cta-block.scss
+++ b/assets/scss/6-components/cta-block/_cta-block.scss
@@ -48,7 +48,7 @@ $cta-block-btn-height: px-to-rem(29px);
     // container should become two columns on wide screens
     &--horiz-from-bp-m {
       @include gap($size-l);
-      align-items: end;
+      align-items: center;
       grid-template-columns: 1fr $cta-block-min-col;
     }
   }

--- a/assets/scss/6-components/cta-block/cta-block.html
+++ b/assets/scss/6-components/cta-block/cta-block.html
@@ -71,7 +71,7 @@
       </p>
       <p class="is-sr-only">Sept. 26</p>
     </div>
-    <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center">
+    <div class="c-cta-block__btns c-cta-block__btns--2 t-align-center l-align-end-self">
       <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
         Attend
       </a>

--- a/assets/scss/6-components/event-block/event-block.html
+++ b/assets/scss/6-components/event-block/event-block.html
@@ -24,7 +24,7 @@
       </p>
       <p class="is-sr-only">Sept. 26</p>
     </div>
-    <div class="c-cta-block__btns c-cta-block__btns--2 c-cta-block__btns--1-from-bp-m t-align-center">
+    <div class="c-cta-block__btns c-cta-block__btns--2 c-cta-block__btns--1-from-bp-m t-align-center l-align-end-self">
       <a class="c-button c-button--standard has-bg-blue has-text-black l-align-center-children t-size-xs" href="#">
         Attend
       </a>


### PR DESCRIPTION
#### What's this PR do?

Satisfies design request of bottom button alignment here:
![Screen Shot 2019-12-06 at 12 05 55 PM](https://user-images.githubusercontent.com/2974713/70345245-32978680-1821-11ea-8652-740930a741fb.png)

but not here:
![Screen Shot 2019-12-06 at 12 06 30 PM](https://user-images.githubusercontent.com/2974713/70345257-39be9480-1821-11ea-8956-718c948e3c6c.png)

#### Why are we doing this? How does it help us?

The call to action plugins look weird with bottom alignment for the buttons.


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Goes with https://github.com/texastribune/texastribune/pull/3756/files

This is breaking-ish but since it's so subtle, I'll just call this a patch.

#### TODOs / next steps:

* [ ] *your TODO here*
