### PR TITLE
Deploy to github pages instead of surge

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint:css": "stylelint 'assets/**/**.scss'",
     "lint:js": "eslint docs/config",
     "lint": "npm run lint:css && npm run lint:js",
-    "deploy": "npm run build && surge ./docs/dist --domain 'https://ttds.surge.sh/'",
+    "deploy": "push-dir --dir=docs/dist --branch=gh-pages",
     "build": "node docs/config/tasks/build.js",
     "dev": "node docs/config/tasks/dev.js",
     "test": "yarn run lint && yarn run build",
@@ -124,6 +124,7 @@
     "prettier": "1.19.1",
     "purgecss": "^1.3.0",
     "purgecss-from-html": "^1.1.0",
+    "push-dir": "^0.4.1",
     "stylelint": "^11.0.0",
     "surge": "^0.21.3"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -5319,6 +5319,13 @@ purgecss@^1.3.0:
     postcss-selector-parser "^6.0.0"
     yargs "^14.0.0"
 
+push-dir@^0.4.1:
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/push-dir/-/push-dir-0.4.1.tgz#29481eacd9c2106bbb7941db6d37d122a071ecb4"
+  integrity sha1-KUgerNnCEGu7eUHbbTfRIqBx7LQ=
+  dependencies:
+    minimist "^1.2.0"
+
 q@^1.1.2:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/q/-/q-1.5.1.tgz#7e32f75b41381291d04611f1bf14109ac00651d7"


### PR DESCRIPTION
#### What's this PR do?

Switched deployment pipeline from surge to github page.

#### Why are we doing this? How does it help us?

GitHub pages is more packaged up with the repo itself. Surge was always a temporary home for the assets. The package that does this was [recommended in the Nuxt.js docs](https://nuxtjs.org/faq/github-pages/#command-line-deployment)

#### How should this be manually tested?
`yarn deploy`

See: [Github page](https://texastribune.github.io/queso-ui/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope just a docs update.




