### PR TITLE
Fix deployment in actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,29 +1,24 @@
-name: Build and Deploy
 
+name: Deploy to GitHub Pages
 on:
   push:
     branches:
-    - master
-    # file paths to consider in the event.
+      - test-deploy
 jobs:
-  build:
-
+  build-and-deploy:
     runs-on: ubuntu-latest
-
-    strategy:
-      matrix:
-        node-version: [11.x]
-
     steps:
-    - uses: actions/checkout@v1
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        node-version: ${{ matrix.node-version }}
-    - name: yarn install, build, and deploy
+    - name: Checkout
+      uses: actions/checkout@v1
+
+    - name: Build
       run: |
         yarn
         yarn build
-        yarn deploy
+
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@releases/v3
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages
+        FOLDER: docs/dist

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,7 +3,7 @@ name: Deploy to GitHub Pages
 on:
   push:
     branches:
-      - test-deploy
+      - master
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
#### What's this PR do?

Uses GitHub [actions tools](https://github.com/marketplace/actions/deploy-to-github-pages) to auto push the `docs/dist` folder to the branch `gh-pages`


#### Why are we doing this? How does it help us?

We won't have to manually deploy the docs. This actions helper is referenced in [this article](https://dev.to/pierresaid/deploy-node-projects-to-github-pages-with-github-actions-4jco).


#### How should this be manually tested?
N/A just does its thing when you push to master

