### PR TITLE
Add a11y fixes to podcast-block

### DIFF
--- a/assets/scss/6-components/podcast-block/_podcast-block.scss
+++ b/assets/scss/6-components/podcast-block/_podcast-block.scss
@@ -7,9 +7,22 @@
 //
 // Styleguide 6.1.3
 .c-podcast-block {
-  @include gap;
+  @include col-gap;
+  @include row-gap($size-xxxs);
   display: grid;
+  grid-template-columns: 1fr;
+  grid-template-areas: 'image-wrap' 'content';
+
+  &__image-wrap {
+    grid-area: image-wrap;
+  }
+
+  &__content {
+    grid-area: content;
+  }
+
   @include mq($from: bp-l) {
+    grid-template-areas: 'image-wrap content';
     grid-template-columns: 7fr 6fr;
     // HACK: Align the last element to the bottom (only works with 3 rows :( )
     &__content {

--- a/assets/scss/6-components/podcast-block/podcast-block.html
+++ b/assets/scss/6-components/podcast-block/podcast-block.html
@@ -1,14 +1,8 @@
 <article class="c-podcast-block">
-  <figure class="l-display-block l-width-full">
-    <a href="#" class="has-text-gray-dark has-text-white">
-      <!-- optionally use srcset for optimizing image delivery -->
-      <img class="l-display-block l-width-full" src="{{ siteURL }}/img/podcast-block/c-podcast-block-thumb.png" alt="Album art for The Brief podcast">
-    </a>
-  </figure>
-  <section class="c-podcast-block__content">
-    <h3 class="t-serif has-xxxs-btm-marg t-size-l t-links-underlined-hover">
+  <div class="c-podcast-block__content">
+    <h2 class="t-serif has-xxxs-btm-marg t-size-l t-links-underlined-hover">
       <a href="/podcast/the-brief/">The Brief</a>
-    </h3>
+    </h2>
     <div class="has-xxxs-btm-marg t-uppercase t-lsp-m t-size-xs"><strong>Monday - Friday</strong></div>
     <div class="has-xxxs-btm-marg t-serif t-links-underlined t-size-b">
       <p> Start your day with a quick take on the latest Texas politics and policy news. Subscribe on
@@ -20,8 +14,12 @@
       </p>
     </div>
     <div class="l-width-full">
-      <div class="t-uppercase t-lsp-m has-text-gray t-size-xxs t-lh-l">Play the latest episode</div>
+      <div class="t-uppercase t-lsp-m has-text-gray-dark t-size-xxs t-lh-l">Play the latest episode</div>
       <div class="has-bg-black has-text-white l-align-center-children" style="height: 78px">Player widget</div>
     </div>
-</section>
+  </div>
+  <a href="#" class="c-podcast-block__image-wrap" tabindex="-1">
+    <!-- optionally use srcset for optimizing image delivery -->
+    <img class="l-display-block l-width-full" src="{{ siteURL }}/img/podcast-block/c-podcast-block-thumb.png" alt="Album art for The Brief podcast">
+  </a>
 </article>


### PR DESCRIPTION
#### What's this PR do?

Reorders the podcast block so that we start with a heading tag

#### Why are we doing this? How does it help us?

Better order for screenreaders

#### How should this be manually tested?
`yarn dev`

See: [c-podcast-block](http://localhost:3000/pages/components/c-podcast-block/raw-preview.html/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Just a patch - this component isn't actually used yet.
