### PR TITLE
Add open sans bold italic back for pullquotes

### DIFF
--- a/assets/scss/5-typography/_font-families.scss
+++ b/assets/scss/5-typography/_font-families.scss
@@ -60,3 +60,13 @@
   font-weight: 400;
   font-style: italic;
 }
+
+
+@font-face {
+  font-display: swap;
+  font-family: 'Open Sans';
+  src: url('https://cdn.texastribune.org/fonts/opensans-bolditalic.woff2') format('woff2'),
+    url('https://cdn.texastribune.org/fonts/opensans-bolditalic.woff') format('woff');
+  font-weight: 700;
+  font-style: italic;
+}

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,11 +1,11 @@
 <div class="c-story-body has-l-btm-marg t-size-b story_body">
   <p>Our editor outputs blocks of texts with paragraph tags. This parent class also accounts for descendant links, headings, horizontal rules, and lists.</p>
-  
+
   <h2>Horizontal Rules</h2>
   <p>Use a horizontal rule to break up content. A horizontal rule is displayed below.</p>
   <hr/>
   <p>The hr tag has built in top and bottom margin. We do this because it's normally used as a spacing element and the need for cushion is assumed.</p>
-  
+
   <h2>Ordered Lists</h2>
   <p>Ordered lists are lists with numbers and need the special container and a list style treatment.</p>
   <ol>
@@ -13,7 +13,7 @@
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ol>
-  
+
   <h2>Unordered Lists</h2>
   <p>Unordered lists are lists with bullets and also need the special container and a list style treatment. We globally remove bullets so lists within the c-story-body class we add them back via the ul tag.</p>
   <ul>
@@ -21,13 +21,18 @@
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ul>
-  
+
   <h2>Headings</h2>
   <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h2.</p>
   <h2>I am an example heading</h2>
-  
+
   <h2>Plugins</h2>
   <p>Plugins are special and have their own rules for positioning. A div without the plugin class will still align with the story text, but any div prefixed with "plugin" will be excluded from the max-width and margin declaration the other elements adhere to.</p>
-  <div class="plugin has-padding has-bg-gray-light">Example of plugin. Should be not be bound by container.</div>
-  <div class="plugin-ad has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>
+  <div class="c-plugin">
+    <blockquote class="has-b-btm-marg has-vert-bar has-vert-bar--padded-l has-text-yellow t-sans t-size-m">
+      <p class="has-text-black-off has-xxxs-btm-marg"><strong><em>“Example of a pull quote.”</em></strong></p>
+      <cite class="has-text-black-off t-size-b">—&nbsp;Whitney Airgood-Obrycki, research associate, Joint Center for Housing Studies</cite>
+    </blockquote>
+  </div>
+  <div class="c-plugin has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>
 </div>

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -31,7 +31,7 @@
   <div class="c-plugin">
     <blockquote class="has-b-btm-marg has-vert-bar has-vert-bar--padded-l has-text-yellow t-sans t-size-m">
       <p class="has-text-black-off has-xxxs-btm-marg"><strong><em>“Example of a pull quote.”</em></strong></p>
-      <cite class="has-text-black-off t-size-b">—&nbsp;Whitney Airgood-Obrycki, research associate, Joint Center for Housing Studies</cite>
+      <cite class="has-text-black-off t-size-b">—&nbsp;First name, Last name</cite>
     </blockquote>
   </div>
   <div class="c-plugin has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>


### PR DESCRIPTION
#### What's this PR do?

Adds Open Sans Bold Italic back for pullquotes

#### Why are we doing this? How does it help us?

I thought this font never appeared, but it does in this rare use case. It won't actually fetch the font unless a pullquote is present



#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?


Nope, just a patch

#### TODOs / next steps:

* [ ] *your TODO here*
