### PR TITLE
Add keyboard navigation enhancements

### DIFF
--- a/assets/scss/1-settings/_measures.scss
+++ b/assets/scss/1-settings/_measures.scss
@@ -127,3 +127,13 @@ $column-slug: col !default;
 // Styleguide 1.3.1
 $border-radius-b: 4px;
 $border-radius-l: 40px;
+
+
+// Utility height
+//
+// We often use navbar and forms with a static height. Declare this variable for consistency across platforms.
+//
+// $util-height = 45px - Standard height of navbar and forms
+//
+// Styleguide 1.3.1
+$util-height: 45px;

--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -55,6 +55,13 @@
     border-bottom: 1px solid rgba($border-hover-color, .6);
     box-shadow: inset 0 -2px 0 0 rgba($border-hover-color, .6);
   }
+  // make focus state more apparent
+  &:focus {
+    outline: none;
+    border-bottom: 1px solid $color-teal-gray;
+    box-shadow: inset 0 -2px 0 0 $color-teal-gray;
+    color: $color-teal-gray;
+  }
 }
 
 
@@ -67,8 +74,8 @@
 // Styleguide 2.1.3
 //
 @mixin underlined-link-parent($hover-only: false) {
-  a:not(.t-unlink) {
-    @include underlined-link($hover-only)
+  a {
+    @include underlined-link($hover-only);
   }
 }
 

--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -57,10 +57,10 @@
   }
   // make focus state more apparent
   &:focus {
-    outline: none;
     border-bottom: 1px solid $color-teal-gray;
     box-shadow: inset 0 -2px 0 0 $color-teal-gray;
     color: $color-teal-gray;
+    outline: none;
   }
 }
 

--- a/assets/scss/3-resets/_all.scss
+++ b/assets/scss/3-resets/_all.scss
@@ -4,5 +4,4 @@
 //
 //
 // Styleguide 3.0.0
-@import 'box-sizing';
-@import 'normalize.css/normalize';
+@import 'node_modules/modern-normalize/modern-normalize.css';

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -36,6 +36,14 @@ a {
   text-decoration: none;
 }
 
+// focus states
+a, button {
+  &:focus {
+    outline: 1px dashed $color-teal-gray;
+    outline-offset: 2px;
+  }
+}
+
 // We want all of our cite elements to not be italicized
 cite {
   font-style: normal;

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -128,7 +128,7 @@
       height: auto;
       left: 0;
       // same height as .c-navbar__top
-      top: 45px;
+      top: $util-height;
       width: auto;
       z-index: 5;
     }

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -49,11 +49,10 @@
   }
 
   &:focus {
-    border-style: solid;
-    border-width: 2px;
+    box-shadow: inset 0 0 0 .2rem;
     color: $color-black-off;
     outline: none;
-    background-color: $color-white-pure;
+    background-color: transparent;
     // extra specific to force color
     .c-button__inner {
       color: $color-black-off;
@@ -103,8 +102,7 @@
     }
 
     &:focus {
-      border-width: 3px;
-      box-shadow: 0 0 0 .2rem rgba($color-black-pure, .5);
+      border-color: currentColor;
     }
 
     &:active {
@@ -148,6 +146,7 @@
 //
 .c-link-button {
   @include underlined-link;
+  color: inherit;
   cursor: pointer;
   line-height: normal;
 }

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -48,6 +48,18 @@
     opacity: 0.6;
   }
 
+  &:focus {
+    border-style: solid;
+    border-width: 2px;
+    color: $color-black-off;
+    outline: none;
+    background-color: $color-white-pure;
+    // extra specific to force color
+    .c-button__inner {
+      color: $color-black-off;
+    }
+  }
+
   &--l {
     font-size: $size-l;
     padding: $size-l;
@@ -90,6 +102,11 @@
       }
     }
 
+    &:focus {
+      border-width: 3px;
+      box-shadow: 0 0 0 .2rem rgba($color-black-pure, .5);
+    }
+
     &:active {
       opacity: 0.7;
     }
@@ -106,19 +123,20 @@
     height: 1px;
     left: -999px;
     position: absolute;
-    overflow: hidden;
     width: 1px;
     z-index: -999;
 
     &:focus {
       height: auto;
       left: 0;
+      // same height as .c-navbar__top
       top: 45px;
       width: auto;
       z-index: 5;
     }
   }
 }
+
 
 // Link button (c-link-button)
 //

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -8,6 +8,7 @@
 // .c-button--xs - Two steps down from default
 // .c-button--circle - Circular button (experimentally used for back to top)
 // .c-button--outline - Hover effect of outline (used on social)
+// .c-button--skip - Visible only on focus, this is used to skip navigation
 //
 // Markup: 6-components/button/button.html
 //
@@ -99,6 +100,23 @@
     padding-bottom: 0;
     height: 26px;
     line-height: 26px;
+  }
+
+  &--skip {
+    height: 1px;
+    left: -999px;
+    position: absolute;
+    overflow: hidden;
+    width: 1px;
+    z-index: -999;
+
+    &:focus {
+      height: auto;
+      left: 0;
+      top: 45px;
+      width: auto;
+      z-index: 5;
+    }
   }
 }
 

--- a/assets/scss/6-components/button/button.html
+++ b/assets/scss/6-components/button/button.html
@@ -10,7 +10,7 @@ Use with vertical centering helper. <code>.l-align-center-y</code>
 <button class="c-button c-button--outline has-text-facebook has-bg-facebook has-text-hover-facebook l-align-center-children">
     <span class="c-button__inner c-icon"><svg aria-hidden="true">
         <use xlink:href="#facebook"></use>
-    </svg></span
+    </svg></span>
 </button>
 {% else %}
 <button class="c-button {{ className }}">

--- a/assets/scss/6-components/mini-form/_mini-form.scss
+++ b/assets/scss/6-components/mini-form/_mini-form.scss
@@ -19,6 +19,6 @@
 
   .c-text-input__input,
   .c-button {
-    height: 45px;
+    height: $util-height;
   }
 }

--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -34,7 +34,7 @@
   &__top {
     flex: 0 1 100%;
     display: flex;
-    height: 45px;
+    height: $util-height;
     justify-content: space-between;
     max-width: 100rem;
     position: relative;

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -1,3 +1,4 @@
+@use "sass:list";
 // Text color (has-text-<color>)
 //
 // Set the color of text. {{isHelper}}
@@ -25,7 +26,7 @@
 // Styleguide 8.0.1
 //
 
-// Text color:hover (has-text-hover-<color>) 
+// Text color:hover (has-text-hover-<color>)
 //
 // Set the color of text on hover. {{isHelper}}
 //
@@ -52,7 +53,7 @@
 // Styleguide 8.0.2
 //
 
-// Background Color (has-bg-<color>) 
+// Background Color (has-bg-<color>)
 //
 // Set the background-color of an element. {{isHelper}}
 //
@@ -98,12 +99,25 @@ $color-map: (
   "facebook": $color-facebook,
 );
 
+// bg-color
 @each $color, $value in $color-map {
   .has-bg-#{$color} {
     background-color: $value;
   }
 }
 
+// used for focus states of buttons
+// we only add to button colors to trim down on unused styles
+$button-colors: "teal", "gray-dark", "blue", "twitter", "facebook", "yellow";
+@each $color in $button-colors {
+  .has-bg-#{$color} {
+    &:focus {
+      border-color: map-get($color-map, $color);
+    }
+  }
+}
+
+// text-hover
 @media (hover: hover) {
   @each $color, $value in $color-map {
     .has-text-hover-#{$color}:hover,
@@ -113,6 +127,7 @@ $color-map: (
   }
 }
 
+// text-color
 @each $color, $value in $color-map {
   .has-text-#{$color} {
     color: $value;

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -1,4 +1,3 @@
-@use "sass:list";
 // Text color (has-text-<color>)
 //
 // Set the color of text. {{isHelper}}
@@ -112,7 +111,7 @@ $button-colors: "teal", "gray-dark", "blue", "twitter", "facebook", "yellow";
 @each $color in $button-colors {
   .has-bg-#{$color} {
     &:focus {
-      border-color: map-get($color-map, $color);
+      box-shadow: inset 0 0 0 .2rem map-get($color-map, $color);
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -5356,8 +5356,8 @@
         "markdown-it": "^10.0.0",
         "nunjucks": "^3.2.0",
         "resolve": "^1.10.1",
-        "twig": "^1.13.3 <1.14.0",
-        "twig-drupal-filters": "^2.0.0",
+        "twig": "^1.15.0",
+        "twig-drupal-filters": "^3.0.0",
         "yargs": "^15.1.0"
       },
       "dependencies": {
@@ -6490,6 +6490,11 @@
           "dev": true
         }
       }
+    },
+    "modern-normalize": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-0.6.0.tgz",
+      "integrity": "sha512-gzvL1uFLV4EErHhaKoqTcrx52/sea6AIcMFWz/GBCuFrDBp485wSgyX5M+MZsj+grfcuqYLQGfHjDRrCvvwZLw=="
     },
     "ms": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -128,6 +128,7 @@
     "stylelint": "^13.0.0"
   },
   "dependencies": {
+    "modern-normalize": "^0.6.0",
     "normalize.css": "^8.0.1",
     "sass-mq": "^5.0.0"
   }


### PR DESCRIPTION
#### What's this PR do?

- Adds a new skip to content link button style
- Adds links/buttons focus states
- Trims down our CSS reset (normalize -> modern-normalize)
- Fixes "Reset Password" text color in donation repo (this lost its color inheritance when I altered the hover styles mixin I think)

##### Classes added (if any)
- c-button--skip
- :focus states added to some has-bg helpers

#### Why are we doing this? How does it help us?

- Better a11y
- Normalize has some extra legacy styles we don't need. I also appreciate that this normalize version has a goal of [eventually going away](https://github.com/sindresorhus/modern-normalize/issues/2)

#### How should this be manually tested?
`npm run dev`

Test out tabbing on [buttons](http://localhost:3000/pages/components/c-button/raw-preview.html), [links](http://localhost:3000/pages/typography/t-%3Clink-style%3E/raw-preview.html), [block-grid](http://localhost:3000/pages/components/c-block-feed/raw-preview.html) or wherever there are links/buttons to tab through.

The skip button is easier to test on prod. I'll pre-release so that I can do that.


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

I don't actually think this is breaking, but I'm going to treat it as a major release because it touches defaults.


#### TODOs / next steps:

* [ ] *Pre-release and test in donations/tt*
