### PR TITLE
Remove custom button focus - keep :focus simple for now

### DIFF
--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -37,12 +37,11 @@ a {
 }
 
 // focus states
-a, button {
-  &:focus {
-    outline: 1px dashed $color-teal-gray;
-    outline-offset: 2px;
-  }
+:focus {
+  outline: 2px dotted $color-teal-gray;
+  outline-offset: 5px;
 }
+
 
 // We want all of our cite elements to not be italicized
 cite {

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -48,17 +48,6 @@
     opacity: 0.6;
   }
 
-  &:focus {
-    box-shadow: inset 0 0 0 .2rem;
-    color: $color-black-off;
-    outline: none;
-    background-color: transparent;
-    // extra specific to force color
-    .c-button__inner {
-      color: $color-black-off;
-    }
-  }
-
   &--l {
     font-size: $size-l;
     padding: $size-l;
@@ -101,10 +90,6 @@
       }
     }
 
-    &:focus {
-      border-color: currentColor;
-    }
-
     &:active {
       opacity: 0.7;
     }
@@ -127,6 +112,7 @@
     &:focus {
       height: auto;
       left: 0;
+      outline: none;
       // same height as .c-navbar__top
       top: $util-height;
       width: auto;

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -105,17 +105,6 @@ $color-map: (
   }
 }
 
-// used for focus states of buttons
-// we only add to button colors to trim down on unused styles
-$button-colors: "teal", "gray-dark", "blue", "twitter", "facebook", "yellow";
-@each $color in $button-colors {
-  .has-bg-#{$color} {
-    &:focus {
-      box-shadow: inset 0 0 0 .2rem map-get($color-map, $color);
-    }
-  }
-}
-
 // text-hover
 @media (hover: hover) {
   @each $color, $value in $color-map {


### PR DESCRIPTION
#### What's this PR do?

Dials back some of the previously added focus states.

#### Why are we doing this? How does it help us?

When I tested the new focus states in the main /texastribune repo, they were a little confusing. I think just relying on the outline is good for now, but will check with Art.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Another pre-release.

