### PR TITLE
Prevent mouse click focus state

### DIFF
--- a/assets/scss/1-settings/_colors.scss
+++ b/assets/scss/1-settings/_colors.scss
@@ -63,6 +63,7 @@ $color-twitter: #55acee;
 //
 // Colors:
 // $color-link-underline: $color-blue-light - Link Underline
+// $color-focus-outline: #348094 - Outline color for keyboard tabbing
 // $color-error: #e12931 - Error
 // $color-success: #11A06B - Success
 // $color-fmd-blue-dark: #323a44 - Fall membership drive 1
@@ -73,6 +74,7 @@ $color-twitter: #55acee;
 // Styleguide 1.1.4
 //
 $color-link-underline: $color-blue-light;
+$color-focus-outline: $color-teal-gray;
 $color-error: $color-red;
 $color-success: #11A06B;
 $color-fmd-blue-dark: #323a44;

--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -55,13 +55,6 @@
     border-bottom: 1px solid rgba($border-hover-color, .6);
     box-shadow: inset 0 -2px 0 0 rgba($border-hover-color, .6);
   }
-  // make focus state more apparent
-  &:focus {
-    border-bottom: 1px solid $color-teal-gray;
-    box-shadow: inset 0 -2px 0 0 $color-teal-gray;
-    color: $color-teal-gray;
-    outline: none;
-  }
 }
 
 

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -38,7 +38,7 @@ a {
 
 // focus states
 :focus {
-  outline: 2px dotted $color-teal-gray;
+  outline: 2px dotted $color-focus-outline;
   outline-offset: 5px;
 }
 
@@ -47,7 +47,7 @@ a {
 }
 
 :focus-visible {
-  outline: 2px dotted $color-teal-gray;
+  outline: 2px dotted $color-focus-outline;
   outline-offset: 5px;
 }
 

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -42,6 +42,14 @@ a {
   outline-offset: 5px;
 }
 
+:focus:not(:focus-visible) {
+  outline: none;
+}
+
+:focus-visible {
+  outline: 2px dotted $color-teal-gray;
+  outline-offset: 5px;
+}
 
 // We want all of our cite elements to not be italicized
 cite {


### PR DESCRIPTION
#### What's this PR do?

Removes mouse click focus state.


#### Why are we doing this? How does it help us?

We don't want our dotted outlines for mouse users


#### How should this be manually tested?
`yarn dev`

See: [any page](http://localhost:3000/)

Tab around and click around. You should see link outlines on tabs, but not clicks


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?


Another pre-release of v9

#### TODOs / next steps:

* [ ] *test in texastribune*
