### PR TITLE
Remove outline on click in firefox/legacy styles in docs

### DIFF
--- a/assets/scss/3-resets/_all.scss
+++ b/assets/scss/3-resets/_all.scss
@@ -1,7 +1,13 @@
 // Resets
 //
-// We want to import normalize instead. It's around 6kb and we can update versions as https://github.com/necolas/normalize.css changes.
+// We use [modern-normalize](https://github.com/sindresorhus/modern-normalize/blob/master/modern-normalize.css) and extra resets of our own.
 //
 //
 // Styleguide 3.0.0
+
+// weird quirk of FireFox showing the outline on click
+a:active,
+a:hover {
+  outline: 0;
+}
 @import 'node_modules/modern-normalize/modern-normalize.css';

--- a/docs/config/paths.js
+++ b/docs/config/paths.js
@@ -10,10 +10,6 @@ const mappedStyles = [
     out: `${buildDir}css/all.css`,
   },
   {
-    in: './assets/scss/all-legacy.scss',
-    out: `${buildDir}css/all-legacy.css`,
-  },
-  {
     in: './assets/scss/no-resets.scss',
     out: `${buildDir}css/no-resets.css`,
   },

--- a/docs/src/includes/header.html
+++ b/docs/src/includes/header.html
@@ -1,6 +1,6 @@
 <header class="ds-header container level">
   <div class="level-left">
-    <h1 class="level-item">
+    <h1 class="level-item is-size-3">
       <a href="/">queso-ui 🧀</a>
     </h1>
     <p class="level-item">

--- a/docs/src/index.html
+++ b/docs/src/index.html
@@ -8,7 +8,6 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>CSS + HTML Guide for The Texas Tribune</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link rel="stylesheet" href="css/all-legacy.css" />
   <link rel="stylesheet" href="css/all.css" />
   <link rel="stylesheet" href="css/ds.css" />
 </head>

--- a/docs/src/page.html
+++ b/docs/src/page.html
@@ -13,7 +13,6 @@
   <meta content="ie=edge" http-equiv="X-UA-Compatible" />
   <title>{{name}} | Style Docs for The Texas Tribune.</title>
   <link href="https://cdnjs.cloudflare.com/ajax/libs/bulma/0.7.2/css/bulma.min.css" rel="stylesheet" />
-  <link rel="stylesheet" href="../../css/all-legacy.css" />
   <link rel="stylesheet" href="../../css/all.css" />
   <link rel="stylesheet" href="../../css/ds.css" />
 </head>


### PR DESCRIPTION
#### What's this PR do?

- Stops referencing legacy styles in docs
- Removes visible focus state of mouse click in firefox

#### Why are we doing this? How does it help us?

Just a weird browser quirk


#### How should this be manually tested?
`yarn dev`

See: [index](http://localhost:3000/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Another pre

