### PR TITLE
Undo major changes for minor release features

### DIFF
--- a/assets/scss/3-resets/_all.scss
+++ b/assets/scss/3-resets/_all.scss
@@ -1,13 +1,7 @@
 // Resets
 //
-// We use [modern-normalize](https://github.com/sindresorhus/modern-normalize/blob/master/modern-normalize.css) and extra resets of our own.
-//
+// We import the standard https://github.com/necolas/normalize.css reset, but in the future we'll revist this to replace with something potentially smaller.
 //
 // Styleguide 3.0.0
-
-// weird quirk of FireFox showing the outline on click
-a:active,
-a:hover {
-  outline: 0;
-}
-@import 'node_modules/modern-normalize/modern-normalize.css';
+@import 'box-sizing';
+@import 'normalize.css/normalize';

--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -36,21 +36,6 @@ a {
   text-decoration: none;
 }
 
-// focus states
-:focus {
-  outline: 2px dotted $color-focus-outline;
-  outline-offset: 5px;
-}
-
-:focus:not(:focus-visible) {
-  outline: none;
-}
-
-:focus-visible {
-  outline: 2px dotted $color-focus-outline;
-  outline-offset: 5px;
-}
-
 // We want all of our cite elements to not be italicized
 cite {
   font-style: normal;

--- a/package-lock.json
+++ b/package-lock.json
@@ -385,10 +385,9 @@
       }
     },
     "acorn": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.0.tgz",
-      "integrity": "sha512-gac8OEcQ2Li1dxIEWGZzsp2BitJxwkwcOm0zHAJLcPJaVvm58FRnk6RkuLRpU1EujipU2ZFODv2P9DLMfnV8mw==",
-      "dev": true
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.4.1.tgz",
+      "integrity": "sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA=="
     },
     "acorn-jsx": {
       "version": "5.1.0",
@@ -5502,6 +5501,27 @@
             "ansi-regex": "^5.0.0"
           }
         },
+        "twig": {
+          "version": "1.15.0",
+          "resolved": "https://registry.npmjs.org/twig/-/twig-1.15.0.tgz",
+          "integrity": "sha512-kJkEbF4sTyZcaMAXffCjaUt6ZSD3v6qZQZd9b6mySvfuUIseTCJCvikphAJvrNJTDw7nZDfGorvTtUkzge1HPg==",
+          "dev": true,
+          "requires": {
+            "@babel/runtime": "^7.8.4",
+            "locutus": "^2.0.11",
+            "minimatch": "3.0.x",
+            "walk": "2.3.x"
+          }
+        },
+        "twig-drupal-filters": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/twig-drupal-filters/-/twig-drupal-filters-3.1.0.tgz",
+          "integrity": "sha512-NvlIYvDH1wAafiMq9tEaGUpDqUFYYYLgXk0ESHd/YQ4rBuRVhCZTHidTeKj7NhF+8gI95H+XaRmc8sP32WuJNw==",
+          "dev": true,
+          "requires": {
+            "twig": "^1.15.0"
+          }
+        },
         "which-module": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/which-module/-/which-module-2.0.0.tgz",
@@ -6490,11 +6510,6 @@
           "dev": true
         }
       }
-    },
-    "modern-normalize": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/modern-normalize/-/modern-normalize-0.6.0.tgz",
-      "integrity": "sha512-gzvL1uFLV4EErHhaKoqTcrx52/sea6AIcMFWz/GBCuFrDBp485wSgyX5M+MZsj+grfcuqYLQGfHjDRrCvvwZLw=="
     },
     "ms": {
       "version": "2.0.0",
@@ -9041,12 +9056,6 @@
         }
       }
     },
-    "slugg": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/slugg/-/slugg-1.2.1.tgz",
-      "integrity": "sha1-51KvIkGvPycURjxd4iXOpHYIdAo=",
-      "dev": true
-    },
     "snapdragon": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
@@ -10377,27 +10386,6 @@
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
       "dev": true
-    },
-    "twig": {
-      "version": "1.13.3",
-      "resolved": "https://registry.npmjs.org/twig/-/twig-1.13.3.tgz",
-      "integrity": "sha512-Kjart2102Kf0IdsEmLonSJKcByU7o9uiJhBde3GhrNHrX4XenT5WSKu4Hpkx+rF6Kyppeyd48BKsCREIOPXd/g==",
-      "dev": true,
-      "requires": {
-        "locutus": "^2.0.5",
-        "minimatch": "3.0.x",
-        "walk": "2.3.x"
-      }
-    },
-    "twig-drupal-filters": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/twig-drupal-filters/-/twig-drupal-filters-2.0.0.tgz",
-      "integrity": "sha1-/T42rf1jmNWx0BL5UKX5q9VYG1o=",
-      "dev": true,
-      "requires": {
-        "slugg": "^1.2.1",
-        "twig": "^1.12.0"
-      }
     },
     "type-check": {
       "version": "0.3.2",

--- a/package.json
+++ b/package.json
@@ -128,7 +128,6 @@
     "stylelint": "^13.0.0"
   },
   "dependencies": {
-    "modern-normalize": "^0.6.0",
     "normalize.css": "^8.0.1",
     "sass-mq": "^5.0.0"
   }


### PR DESCRIPTION
#### What's this PR do?
- Removes focus states
- Brings back old normalize

#### Why are we doing this? How does it help us?

I've been doing some thinking about the next major release and I want to save v9 for the color overhaul. We need to rename a bunch of color helpers and make the system more configurable for propublica apps/data-visuals-create
- For that reason, I'm reverting to _normal_ normalize to be able to just make this another minor release; let's save something that global for v9
- There's a blip of our dotted outlines we set for focus state as the page loads and I'm just not ready to introduce that. Seems like another good candidate for v9

#### How should this be manually tested?
`npm run dev`

See: [your-link](http://localhost:3000/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

This will allow us to officially release 8.4

