### PR TITLE
Add story body modifier for nested plugins

### DIFF
--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -2,12 +2,18 @@
 //
 // Story bodies are a special component because we have limited control over the class names within them. We must deviate from BEM and create catch-all tag selectors to allow the greatest flexibility of the markup.
 //
+// .c-story-body--nested - Assumes story body is wrapped in another component.
+//
 // Markup: 6-components/story-body/story-body.html
 //
 // Styleguide 6.1.3
 
 $story-padding-buffer: 2em; // must be em for SASSmq helper
 $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
+
+:root {
+  --story-body-padding: #{$size-xs};
+}
 
 .c-story-body {
   > p,
@@ -24,7 +30,7 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     margin: $size-b auto;
     line-height: 1.4;
     @include mq($until: $story-narrow-bp) {
-      padding: 0 $size-xs;
+      padding: 0 var(--story-body-padding);
     }
   }
 
@@ -61,5 +67,9 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
 
   hr {
     margin: $size-xl auto;
+  }
+
+  &--nested {
+    --story-body-padding: 0;
   }
 }

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,4 +1,5 @@
-<div class="c-story-body has-l-btm-marg t-size-b story_body">
+<div class="c-story-body {{ className }} has-l-btm-marg t-size-b story_body">
+  <h1>{{ className }}</h1>
   <p>Our editor outputs blocks of texts with paragraph tags. This parent class also accounts for descendant links, headings, horizontal rules, and lists.</p>
 
   <h2>Horizontal Rules</h2>


### PR DESCRIPTION
#### What's this PR do?

Adds a new CSS variable to `c-story-body` for easier overrides. Also adds a modifier, which makes use of that.

##### Classes added (if any)
- c-story-body--nested

#### Why are we doing this? How does it help us?

I realized that assuming you always want story body children to have mobile padding is a bit restricting. Example: this callout plugin:
<img width="405" alt="Screen Shot 2020-04-08 at 11 54 28 AM" src="https://user-images.githubusercontent.com/2974713/78811645-c88a1c00-798f-11ea-9b64-844168ea1a8e.png">


It would be better if the text was flush
<img width="407" alt="Screen Shot 2020-04-08 at 11 53 04 AM" src="https://user-images.githubusercontent.com/2974713/78811537-a0022200-798f-11ea-8411-4a96bff9fc5f.png">


#### How should this be manually tested?
`npm run dev`

See: [c-story-body](http://localhost:3000/pages/components/index.html#story-body-c-story-body)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Just a minor release
