### PR TITLE
Update .c-topic bar

### DIFF
--- a/assets/scss/6-components/topic-bar/_topic-bar.scss
+++ b/assets/scss/6-components/topic-bar/_topic-bar.scss
@@ -1,21 +1,77 @@
 // Topic bar (c-topic-bar)
 //
-// Horizontal list of links. This is found on the homepage in a flatblock. For layout, use `l-align-center-children` in the markup. We rely on inheritance for this component to simplify the markup.
+// Horizontal list of links that intentionally overflows on mobile. Found on the homepage and story pages. The list items are editable via flatblock. We rely on inheritance for this component to simplify the markup.
 //
-// Keywords: flatblock
+// .c-topic-bar--sticky - Stick to the top of the screen
+// .c-topic-bar--btm-border - Add a thin gray bottom border
+// .c-topic-bar--top-border-until-bp-l - Add a top gray border on small screens
 //
 // Markup: 6-components/topic-bar/topic-bar.html
 //
 // Styleguide 6.1.5
 .c-topic-bar {
-  li {
-    margin: 0 auto;
-    padding: 0 $size-tiny;
+  $gradient-width: 5rem;
+  position: relative;
+
+  &--sticky {
+    position: sticky;
+    top: 0;
+    z-index: 1;
   }
 
-  a {
-    &:hover {
-      color: $color-teal-gray;
+  &--btm-border {
+    border-bottom: 1px solid $color-gray-light;
+  }
+
+  @include mq($until: bp-l) {
+    &:after {
+      background: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, rgba(255, 255, 255, 1) 100%);
+      content: '';
+      height: 100%;
+      position: absolute;
+      pointer-events: none;
+      right: 0;
+      top: 0;
+      width: $gradient-width;
+    }
+
+    &--top-border-until-bp-l {
+      border-top: 1px solid $color-gray-light;
+    }
+  }
+
+  &__inner {
+    -webkit-overflow-scrolling: touch;
+    overflow-x: auto;
+    padding: $size-b $size-s;
+  }
+
+  ul {
+    align-items: center;
+    display: flex;
+
+    @include mq($from: bp-l) {
+      justify-content: center;
+    }
+
+    li {
+      padding-right: $size-xl;
+
+      &:last-child {
+        padding-right: $gradient-width;
+      }
+
+      @include mq($until: bp-l) {
+        flex-shrink: 0;
+      }
+
+      @include mq($from: bp-l) {
+        padding-right: $size-xxxl;
+
+        &:last-child {
+          padding-right: 0;
+        }
+      }
     }
   }
 }

--- a/assets/scss/6-components/topic-bar/topic-bar.html
+++ b/assets/scss/6-components/topic-bar/topic-bar.html
@@ -1,8 +1,14 @@
-<ul class="c-topic-bar l-align-center-children t-size-xs t-serif t-weight-bold t-align-center">
-  <li><p class="t-uppercase t-size-xxs t-lsp-b t-sans has-text-gray-dark">In the news</p></li>
-  <li><a href="#">Elaine Benes</a></li>
-  <li><a href="#">Newman</a></li>
-  <li><a href="#">No soup for you</a></li>
-  <li><a href="#">Keith Hernandez</a></li>
-  <li><a href="#">The Pez Dispenser</a></li>
-</ul>
+<div class="c-topic-bar {{ className }} t-links-underlined-hover t-size-xs t-align-center has-bg-white" aria-labelledby="topic-bar-label">
+  <h2 id="topic-bar-label" class="is-sr-only">Key coverage</h2>
+  <div class="c-topic-bar__inner">
+    <ul>
+      <li aria-hidden="true" class="t-size-xxs">
+        <strong>KEY COVERAGE</strong>
+      </li>
+      <li><a href="#">How to Get Help</a></li>
+      <li><a href="#">Coronavirus Newsletter</a></li>
+      <li><a href="#">Life in the Pandemic</a></li>
+      <li><a href="#">Unemployment Benefits</a></li>
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
#### What's this PR do?
Makes the topic bar mobile friendly, sans-serif-y and sticky

##### Classes added (if any)
Just some modifiers on `.c-topic-bar`.

#### Why are we doing this? How does it help us?
Mobile is where it's at

#### How should this be manually tested?
`npm run dev` and check out `.c-topic-bar`

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
Minor release to come.