### PR TITLE
Fix modern-normalize import and update footer example

### DIFF
--- a/assets/scss/3-resets/_all.scss
+++ b/assets/scss/3-resets/_all.scss
@@ -3,4 +3,4 @@
 // [Modern normalize](https://github.com/sindresorhus/modern-normalize)
 //
 // Styleguide 3.0.0
-@import 'node_modules/modern-normalize/modern-normalize.css';
+@import 'modern-normalize/modern-normalize';

--- a/assets/scss/6-components/site-footer/_site-footer.scss
+++ b/assets/scss/6-components/site-footer/_site-footer.scss
@@ -1,13 +1,22 @@
 // Site footer (c-site-footer)
 //
-// The footer of our site. {{isWide}}
-//
+// The standard footer on our site. Set the layout based on the number of columns needed. <br><br>
+//  _Example CSS for layout:_
+// ```css
+// .c-site-footer__inner {grid-template-columns: repeat(4, 1fr);}
+// ```
+// <br><br>
 //
 // Markup: 6-components/site-footer/site-footer.html
 //
 // Styleguide 6.1.3
 .c-site-footer {
   padding: $size-xxl $size-xxl $size-giant $size-xxl;
+
+  &__inner {
+    @include gap;
+    display: grid;
+  }
 
   &__header {
     letter-spacing: .08em;

--- a/assets/scss/6-components/site-footer/site-footer.html
+++ b/assets/scss/6-components/site-footer/site-footer.html
@@ -4,8 +4,8 @@
     with different links, number of columns, etc. You'll likely need
     to implement a grid system at the app level to handle those scenarios.
   -->
-  <div class="c-site-footer__inner l-container l-container--xl grid_row">
-    <div class="col">
+  <div class="c-site-footer__inner l-container l-container--xl t-size-xs">
+    <div>
       <div class="has-b-btm-marg">
         <span style="font-size: 4rem;" class="c-icon has-text-yellow">
           <svg aria-hidden="true" focusable="false">
@@ -15,16 +15,14 @@
       </div>
 
       <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-      
       <ul class="c-site-footer__links t-size-xs has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg"><a class="has-text-blue has-text-hover-blue" href="https://support.texastribune.org/donate">Donate</a></li>
+        <li class="has-tiny-btm-marg has-text-blue has-text-hover-blue"><a href="https://support.texastribune.org/donate">Donate</a></li>
         <li class="has-tiny-btm-marg"><a href="https://www.texastribune.org/contact/">Contact Us</a></li>
         <li>&copy; 2019 The Texas Tribune</li>
       </ul>
     </div>
-    
-    <div class="col t-size-xs">
-      <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg">Heading</h5>
+    <div>
+      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
         <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
         <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
@@ -33,9 +31,8 @@
         <li><a href="#">World</a></li>
       </ul>
     </div>
-
-    <div class="col t-size-xs">
-      <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg">Heading</h5>
+    <div>
+      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
         <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
         <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
@@ -44,9 +41,8 @@
         <li class="has-tiny-btm-marg"><a href="#">World</a></li>
       </ul>
     </div>
-    
-    <div class="col t-size-xs">
-      <h5 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg">Social Media</h5>
+    <div>
+      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Social Media</h2>
       <ul class="c-site-footer__links has-b-btm-marg has-text-white has-text-hover-white">
         <li class="has-tiny-btm-marg">
           <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#facebook"></use></svg></span>


### PR DESCRIPTION
#### What's this PR do?

- Addresses a bug I found when trying to add v9 to other repos. (That's what I get for not pre-releasing!)
- Also just a little revisit of the footer docs

##### Classes added (if any)
- `.c-site-footer__inner ` got some default display and spacing.

#### Why are we doing this? How does it help us?

With the way I had that Sass import for modern-normalize set up, it directly added it as an import instead of outputting the content of that CSS file when compiled out. We don't want that.

I noticed the headings on our footer examples deviated a little from how we usually display them and I feel like since we're always adding a grid might as well include that, but still keep the count general. Open to feedback there - not a huge deal either way!


#### How should this be manually tested?
`npm run dev`

See: [footer](http://localhost:8080/sections/components/c-site-footer/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Patch


#### TODOs / next steps:

* [ ] *Bump to 9.0.1*
