### PR TITLE
Add new position helpers + caption variation

### DIFF
--- a/assets/scss/6-components/caption/_caption.scss
+++ b/assets/scss/6-components/caption/_caption.scss
@@ -4,6 +4,7 @@
 //
 // c-caption--wide - The removal of padding comes a bit sooner.
 // c-caption--compact - Just a bit o' top padding.
+// c-caption--overlay-from-bp-l - Black overlay caption (desktop only).
 //
 // Markup: 6-components/caption/caption.html
 //
@@ -11,6 +12,7 @@
 .c-caption {
   margin: -5px 0 0 0; // not sure what this accounts for (copied from base)
   padding: $size-xs;
+  color: $color-gray-dark;
 
   &--compact {
     padding: $size-xxxs 0 0;
@@ -25,6 +27,14 @@
     @include mq($from: bp-m) {
       padding-left: 0;
       padding-right: 0;
+    }
+  }
+  @include mq($from: bp-l) {
+    &--overlay-from-bp-l {
+      background-color: rgba(30, 30, 30, .8);
+      bottom: 0;
+      color: $color-white-pure;
+      position: absolute;
     }
   }
 }

--- a/assets/scss/6-components/caption/caption.html
+++ b/assets/scss/6-components/caption/caption.html
@@ -1,8 +1,8 @@
-<figure>
+<figure class="l-pos-rel">
   <img
   class="l-display-block l-width-full" src="{{ siteURL }}/img/DEFAULT_LEAD_ART.jpg" alt="Placeholder image of Texas Capitol dome and Texas Tribune branding"
   />
-  <figcaption class="c-caption {{className}} has-text-gray-dark l-display-block t-size-xs">
+  <figcaption class="c-caption {{className}}{% if className == 'c-caption--overlay-from-bp-l' %} has-xs-padding l-width-full{% endif %} l-display-block t-size-xs">
   This is an image caption describing the image above. <span class="c-icon c-icon--baseline"><svg aria-hidden="true"><use xlink:href="#camera"></use></svg></span> <cite>Photographer Name for Company XYZ</cite>
   </figcaption>
 </figure>

--- a/assets/scss/7-layout/_all.scss
+++ b/assets/scss/7-layout/_all.scss
@@ -9,4 +9,5 @@
 @import 'content-grid';
 @import 'display';
 @import 'multicol';
+@import 'position';
 @import 'width';

--- a/assets/scss/7-layout/_position.scss
+++ b/assets/scss/7-layout/_position.scss
@@ -1,0 +1,18 @@
+// Position (l-pos-<setting>)
+//
+// Helper for quickly setting `position: absolute` or `position: relative`. {{isHelper}}
+//
+// .l-pos-rel - Relative position
+// .l-pos-abs - Set _`.l-pos-rel`_ on the parent to place within a defined space.
+//
+// Markup: 7-layout/position.html
+//
+//
+// Styleguide 7.0.5
+.l-pos-rel {
+  position: relative;
+}
+
+.l-pos-abs {
+  position: absolute;
+}

--- a/assets/scss/7-layout/position.html
+++ b/assets/scss/7-layout/position.html
@@ -1,0 +1,10 @@
+{% if className == 'l-pos-rel' %}
+  <div style="border: 1px solid #000; width: 300px; height: 100px;">
+    <span class="{{ className }}" style="background-color: #222; color: #fff; padding: 10px;">position: relative</span>
+  </div>
+{% endif %}
+{% if className == 'l-pos-abs' %}
+  <div class="l-pos-rel" style="border: 1px solid #000; width: 300px; height: 100px;">
+    <span class="{{ className }}" style="background-color: #222; color: #fff; padding: 10px; bottom: 0; right: 0; width: 60%;">position: absolute; bottom: 0; right: 0;</span>
+  </div>
+{% endif %}


### PR DESCRIPTION
#### What's this PR do?
Adds a few helpers for setting `position:` and a variation for captions (to be used on [full-width desktop photos](https://test.texastribune.org/2019/12/12/trumps-immigration-policies-have-slowed-migrants-central-america/))


##### Classes added (if any)
- l-pos-rel
- l-pos-abs
- c-caption--overlay-from-bp-l

#### Why are we doing this? How does it help us?

I think we need some combo of position relative and/or absolute enough that they're deserving of their own helper. I did struggle as to whether they would be a utility class or layout.

#### How should this be manually tested?
`npm run dev`

See: [The new position helpers](http://localhost:8080/sections/layout/l-pos-setting/)
**Questions:** Are these names intuitive? Do they belong in layouts or would you more naturally look in utilities for this?

See: [Captions - .c-caption--overlay-from-bp-l](http://localhost:8080/sections/components/c-caption/)
**Questions:** Should this variation be in the base or does it seem more repo-specific? Incorporating this variation at the base made the color helper obsolete because the caption overlay variation is gray, but then white on desktop 😞 . I started to add a separate responsive color helper at the repo level, but it felt weird to not support properly colored captions globally. 


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

I started to swap out all the components that declare one of these positions with their respective helpers, but that's a pretty involved clean up effort and a breaking change. I made it a [BC task](https://3.basecamp.com/3098728/buckets/736178/todos/2712267154) instead to tackle it separately so I can quickly ship full-width photos. I do think it's important to do after this to keep our CSS slim and trim.


#### TODOs / next steps:

* [ ] *your TODO here*
