### PR TITLE
Establish more text rules in story body  

### DIFF
--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -1,8 +1,7 @@
 // Story body (c-story-body)
 //
-// Story bodies are a special component because we have limited control over the class names within them. We must deviate from BEM and create catch-all tag selectors to allow the greatest flexibility of the markup.
+// The approach for `c-story-body` is different from other components because we use descendant selectors instead of BEM.
 //
-// .c-story-body--nested - Assumes story body is wrapped in another component.
 //
 // Markup: 6-components/story-body/story-body.html
 //
@@ -26,9 +25,10 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
   > ol,
   > span,
   > hr {
+    @include underlined-link-parent;
     max-width: $story-narrow;
     margin: $size-b auto;
-    line-height: 1.4;
+    line-height: $font-line-height-b;
     @include mq($until: $story-narrow-bp) {
       padding: 0 var(--story-body-padding);
     }
@@ -39,7 +39,6 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
   > ul,
   > ol {
     @include font-setting('secondary');
-    @include underlined-link-parent;
   }
 
   > ul,
@@ -55,10 +54,25 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     list-style: disc;
   }
 
-  // h2s are a dropdown option in the CMS
-  // we hard-set the font size for this reason
+  // The CMS supports h2 - h4
   > h2 {
     font-size: $size-m;
+    margin-top: $size-giant;
+  }
+
+  > h3 {
+    font-size: $size-b;
+    margin-top: $size-xxl;
+  }
+
+  > h4 {
+    font-size: $size-s;
+    margin-top: $size-xl;
+  }
+
+  // don't add too much space if h2 is first
+  > h2:first-child {
+    margin-top: $size-b;
   }
 
   sub, sup {
@@ -69,7 +83,4 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     margin: $size-xl auto;
   }
 
-  &--nested {
-    --story-body-padding: 0;
-  }
 }

--- a/assets/scss/6-components/story-body/_story-body.scss
+++ b/assets/scss/6-components/story-body/_story-body.scss
@@ -75,10 +75,6 @@ $story-narrow-bp: ($story-narrow / 1rem) + $story-padding-buffer;
     margin-top: $size-b;
   }
 
-  sub, sup {
-    position: initial;
-  }
-
   hr {
     margin: $size-xl auto;
   }

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -1,39 +1,37 @@
 <div class="c-story-body {{ className }} has-l-btm-marg t-size-b story_body">
-  <h1>{{ className }}</h1>
+  <h2>Article text formatting preview</h2>
   <p>Our editor outputs blocks of texts with paragraph tags. This parent class also accounts for descendant links, headings, horizontal rules, and lists.</p>
 
-  <h2>Horizontal Rules</h2>
-  <p>Use a horizontal rule to break up content. A horizontal rule is displayed below.</p>
-  <hr/>
-  <p>The hr tag has built in top and bottom margin. We do this because it's normally used as a spacing element and the need for cushion is assumed.</p>
-
-  <h2>Ordered Lists</h2>
-  <p>Ordered lists are lists with numbers and need the special container and a list style treatment.</p>
+  <h2>Lists</h2>
+  <p>Ordered</p>
   <ol>
     <li>This is the first item.</li>
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ol>
-
-  <h2>Unordered Lists</h2>
-  <p>Unordered lists are lists with bullets and also need the special container and a list style treatment. We globally remove bullets so lists within the c-story-body class we add them back via the ul tag.</p>
+  <p>Unordered</p>
   <ul>
     <li>This is the first item.</li>
     <li>This is the second item.</li>
     <li>This is the third item.</li>
   </ul>
-
-  <h2>Headings</h2>
-  <p>Our editor has a dropdown option called <em>Subheader</em> for adding a heading element. By default, that tag is an h2.</p>
-  <h2>I am an example heading</h2>
-
+  <hr/>
+  <p>Headings are used to label sections of the text body. The text below is an example of how h2 - h4 tags should be formatted.</p>
+  <h2>Heading level 2</h2>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam facilis, est error vero distinctio sequi reiciendis ipsam consequuntur enim, aliquam accusamus magni laborum neque reprehenderit labore doloremque nulla ab aspernatur?</p>
+  <h3>Heading level 3 and example of some <em>emphasized text</em>
+  </h3>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam facilis, est error vero distinctio sequi reiciendis ipsam consequuntur enim, aliquam accusamus magni laborum neque reprehenderit labore doloremque nulla ab aspernatur?</p>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam facilis, est error vero distinctio sequi reiciendis ipsam consequuntur enim, aliquam accusamus magni laborum neque reprehenderit labore doloremque nulla ab aspernatur?</p>
+  <h4>Heading level 4 and an example of a heading with a <a href="#">link</a>
+  </h4>
+  <p>Lorem ipsum dolor sit amet consectetur adipisicing elit. Nam facilis, est error vero distinctio sequi reiciendis ipsam consequuntur enim, aliquam accusamus magni laborum neque reprehenderit labore doloremque nulla ab aspernatur?</p>
+  <h2>Horizontal Rules</h2>
+  <p>Use a horizontal rule to break up content. A horizontal rule is displayed below.</p>
+  <hr/>
+  <p>The hr tag has built in top and bottom margin. We do this because it's normally used as a spacing element and the need for cushion is assumed.</p>
+  <hr/>
   <h2>Plugins</h2>
-  <p>Plugins are special and have their own rules for positioning. A div without the plugin class will still align with the story text, but any div prefixed with "plugin" will be excluded from the max-width and margin declaration the other elements adhere to.</p>
-  <div class="c-plugin">
-    <blockquote class="has-b-btm-marg has-vert-bar has-vert-bar--padded-l has-text-yellow t-sans t-size-m">
-      <p class="has-text-black-off has-xxxs-btm-marg"><strong><em>“Example of a pull quote.”</em></strong></p>
-      <cite class="has-text-black-off t-size-b">—&nbsp;First name, Last name</cite>
-    </blockquote>
-  </div>
-  <div class="c-plugin has-padding has-bg-gray-light">Example of ad plugin. Should be not be bound by container</div>
+  <p>We add container rules to specific descendant selectors like paragraphs, headings, lists etc. That means that most elements nested in this component will not be bound by any container and will need their own max-width.</p>
+  <div class="c-plugin has-padding has-bg-gray-light">Plugins should not be bound by any rule in c-story-body. We use separate plugin positioning rules for that.</div>
 </div>

--- a/assets/scss/6-components/story-body/story-body.html
+++ b/assets/scss/6-components/story-body/story-body.html
@@ -2,6 +2,8 @@
   <h2>Article text formatting preview</h2>
   <p>Our editor outputs blocks of texts with paragraph tags. This parent class also accounts for descendant links, headings, horizontal rules, and lists.</p>
 
+  <p>This is a paragraph with some <a href="#">link text</a>. This is how <strong>bolded</strong>, <em>emphasized</em>, <sup>superscript</sup> and <sub>subscript</sub> text displays.</p>
+
   <h2>Lists</h2>
   <p>Ordered</p>
   <ol>


### PR DESCRIPTION
#### What's this PR do?

- Adds more heading rules
- Adds better support for `<sub>` and `<sup>`
- Cleans up `.c-story-body` docs

##### Classes added (if any)
- .c-story-body > more heading tag rules

##### Classes removed (if any)
- .c-story-body > sub, sup (removed rules)
- .c-story-body--nested - That was for a plugin that never came to be.


#### Why are we doing this? How does it help us?
- This is for the new heading tags we'll be seeing in the CMS soon
- I'm not sure why `sub, sup {position: initial;}` was there. Seems like we'd want to be able to use those how they were intended. We use seem to wrap [correction text](https://www.texastribune.org/2020/06/15/texas-coronavirus-cases-increase/) with `sup`, but having the [normalize top, bottom position rules kick in](https://github.com/sindresorhus/modern-normalize/blob/master/modern-normalize.css#L128-L147), doesn't seem to negatively affect anything where I see it used.

#### How should this be manually tested?
`npm run dev`

See: [c-story-body docs example](http://localhost:8080/sections/components/c-story-body/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

No, should be fine. I'll pre-release just to be safe.

