### PR TITLE
New footer docs and mobile footer redesign

### DIFF
--- a/assets/scss/6-components/site-footer/_site-footer.scss
+++ b/assets/scss/6-components/site-footer/_site-footer.scss
@@ -19,7 +19,7 @@
   }
 
   &__header {
-    letter-spacing: .08em;
+    letter-spacing: 0.08em;
   }
 
   &__icon {
@@ -32,6 +32,66 @@
 
     &:hover {
       text-decoration: underline;
+    }
+  }
+}
+
+// test
+.c-site-footer {
+  padding: $size-l $size-b $size-giant;
+
+  &__inner {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
+  &__links {
+    li {
+      margin-bottom: px-to-rem(4px);
+    }
+
+    @include mq($until: bp-m) {
+    }
+  }
+  // remove after 10yr treatment
+  &__logo {
+    // hack: nudge 10yr bug left for alignment of square
+    margin-left: -$size-xxs;
+    margin-bottom: $size-b;
+    width: 66px;
+  }
+
+  @include mq($until: bp-s) {
+    &__inner {
+      @include gap($size-xxl);
+      grid-template-columns: repeat(2, 1fr);
+      grid-template-rows: repeat(3, 1fr);
+    }
+
+    &__col--1 {
+      grid-column: 1 / 2;
+      grid-row: 1 / 2;
+    }
+
+    &__col--3 {
+      grid-column: 2 / 3;
+      grid-row: -1 / 1;
+    }
+
+    &__col--4 {
+      grid-column: 1 / 2;
+      grid-row: 2 / 4;
+    }
+    // increase size of mobile tap targets
+    // @link: https://web.dev/tap-targets
+    &__links {
+      li {
+        margin-bottom: px-to-rem(9px);
+      }
+
+      a {
+        display: block;
+        padding: px-to-rem(2px) 0;
+      }
     }
   }
 }

--- a/assets/scss/6-components/site-footer/_site-footer.scss
+++ b/assets/scss/6-components/site-footer/_site-footer.scss
@@ -1,11 +1,15 @@
 // Site footer (c-site-footer)
 //
-// The standard footer on our site. Set the layout based on the number of columns needed. <br><br>
+// The base footer on our site. Set the layout based on the number of columns needed. <br><br>
 //  _Example CSS for layout:_
 // ```css
 // .c-site-footer__inner {grid-template-columns: repeat(4, 1fr);}
 // ```
-// <br><br>
+// <br>
+//
+// To render the standard footer, use a combination of `c-site-footer__inner--standard` for layout and `c-site-footer__links--standard` for proper link spacing.
+//
+// c-site-footer__inner--standard - This is our default footer.
 //
 // Markup: 6-components/site-footer/site-footer.html
 //
@@ -18,8 +22,18 @@
     display: grid;
   }
 
+  &__inner--standard {
+    grid-template-columns: repeat(4, 1fr);
+  }
+
   &__header {
     letter-spacing: 0.08em;
+  }
+
+  &__links--standard {
+    li {
+      margin-bottom: px-to-rem(4px);
+    }
   }
 
   &__icon {
@@ -34,40 +48,18 @@
       text-decoration: underline;
     }
   }
-}
 
-// test
-.c-site-footer {
-  padding: $size-l $size-b $size-giant;
-
-  &__inner {
-    grid-template-columns: repeat(4, 1fr);
-  }
-
-  &__links {
-    li {
-      margin-bottom: px-to-rem(4px);
-    }
-
-    @include mq($until: bp-m) {
-    }
-  }
-  // remove after 10yr treatment
-  &__logo {
-    // hack: nudge 10yr bug left for alignment of square
-    margin-left: -$size-xxs;
-    margin-bottom: $size-b;
-    width: 66px;
-  }
-
-  @include mq($until: bp-s) {
-    &__inner {
+  // increase size of mobile tap targets
+  // @link: https://web.dev/tap-targets
+  @include mq($until: bp-m) {
+    &__inner--standard {
       @include gap($size-xxl);
       grid-template-columns: repeat(2, 1fr);
       grid-template-rows: repeat(3, 1fr);
     }
 
-    &__col--1 {
+    &__col--1,
+    &__col--4 {
       grid-column: 1 / 2;
       grid-row: 1 / 2;
     }
@@ -78,13 +70,12 @@
     }
 
     &__col--4 {
-      grid-column: 1 / 2;
       grid-row: 2 / 4;
     }
-    // increase size of mobile tap targets
-    // @link: https://web.dev/tap-targets
-    &__links {
+
+    &__links--standard {
       li {
+        font-size: $size-s;
         margin-bottom: px-to-rem(9px);
       }
 

--- a/assets/scss/6-components/site-footer/_site-footer.scss
+++ b/assets/scss/6-components/site-footer/_site-footer.scss
@@ -27,7 +27,7 @@
   }
 
   &__header {
-    letter-spacing: 0.08em;
+    letter-spacing: .08em;
   }
 
   &__links--standard {

--- a/assets/scss/6-components/site-footer/site-footer.html
+++ b/assets/scss/6-components/site-footer/site-footer.html
@@ -1,342 +1,284 @@
-  <!--<div class="c-site-footer has-bg-black-off has-giant-btm-marg">
+{% if className != 'c-site-footer__inner--standard' %}
+  <div class="c-site-footer has-bg-black-off">
+    <!--
+      Our various sites will have different variations on the footer
+      with different links, number of columns, etc. You'll likely need
+      to implement a grid system at the app level to handle those scenarios.
+    -->
+    <div class="c-site-footer__inner l-container l-container--xl t-size-xs">
+      <div>
+        <div class="has-b-btm-marg">
+          <span style="font-size: 4rem;" class="c-icon has-text-yellow">
+            <svg aria-hidden="true" focusable="false">
+              <use xlink:href="#bug"></use>
+            </svg>
+          </span>
+        </div>
 
-    Our various sites will have different variations on the footer
-    with different links, number of columns, etc. You'll likely need
-    to implement a grid system at the app level to handle those scenarios.
-<div class="c-site-footer__inner l-container l-container--xl t-size-xs">
-    <div>
-      <div class="has-b-btm-marg">
-        <span style="font-size: 4rem;" class="c-icon has-text-yellow">
+        <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
+        <ul class="c-site-footer__links t-size-xs has-text-white has-text-hover-white">
+          <li class="has-tiny-btm-marg has-text-blue has-text-hover-blue"><a href="https://support.texastribune.org/donate">Donate</a></li>
+          <li class="has-tiny-btm-marg"><a href="https://www.texastribune.org/contact/">Contact Us</a></li>
+          <li>&copy; 2019 The Texas Tribune</li>
+        </ul>
+      </div>
+      <div>
+        <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
+        <ul class="c-site-footer__links has-text-white has-text-hover-white">
+          <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
+          <li><a href="#">World</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
+        <ul class="c-site-footer__links has-text-white has-text-hover-white">
+          <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
+          <li class="has-tiny-btm-marg"><a href="#">World</a></li>
+        </ul>
+      </div>
+      <div>
+        <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Social Media</h2>
+        <ul class="c-site-footer__links has-b-btm-marg has-text-white has-text-hover-white">
+          <li class="has-tiny-btm-marg">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#facebook"></use></svg></span>
+            <a href="http://facebook.com/texastribune">Facebook</a>
+          </li>
+          <li class="has-tiny-btm-marg">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#twitter"></use></svg></span>
+            <a href="http://twitter.com/texastribune">Twitter</a>
+          </li>
+          <li class="has-tiny-btm-marg">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#youtube"></use></svg></span>
+            <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1">YouTube</a>
+          </li>
+          <li class="has-tiny-btm-marg">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#instagram"></use></svg></span>
+            <a href="http://instagram.com/texas_tribune">Instagram</a>
+          </li>
+          <li class="has-tiny-btm-marg">
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#linkedin"></use></svg></span>
+            <a href="http://www.linkedin.com/company/texas-tribune">LinkedIn</a>
+          </li>
+          <li>
+            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#reddit"></use></svg></span>
+            <a href="https://www.reddit.com/user/texastribune">Reddit</a>
+          </li>
+        </ul>
+
+        <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
+
+        <ul class="c-site-footer__links has-text-white has-text-hover-white">
+          <li>
+            <a href="https://www.facebook.com/groups/thisisyourtexas/">
+              <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true"><use xlink:href="#your-texas"></use></svg></span>
+                Join our Facebook Group, This Is Your Texas.
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+{% else %}
+  <footer class="c-site-footer has-bg-black-off has-text-white t-size-xs">
+    <div class="l-container l-container--xl grid_container--xl c-site-footer__inner c-site-footer__inner--standard">
+      <div class="c-site-footer__col c-site-footer__col--1">
+        <span style="font-size: 4rem;" class="c-icon has-text-yellow has-b-btm-marg">
           <svg aria-hidden="true" focusable="false">
             <use xlink:href="#bug"></use>
           </svg>
         </span>
+        <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg"></div>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li class="has-text-blue">
+            <a href="https://support.texastribune.org/donate?installmentPeriod=once&amp;amount=60" title="Donate" class="donate" ga-on="click" ga-event-category="donations" ga-event-action="membership-intent" ga-event-label="footer">Donate</a>
+          </li>
+
+          <li>
+            <a href="/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
+          </li>
+          <li>
+            <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
+          </li>
+          <li>
+            <a href="/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">© 2020 The Texas Tribune</a>
+          </li>
+        </ul>
       </div>
+      <section id="footer-sections" class="c-site-footer__col--2 hide_until--s is-hidden-until-bp-s">
+        <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
+          Topics
+        </h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a href="/topics/congress/" data-section="congress" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="congress">Congress</a>
+          </li>
+          <li>
+            <a href="/topics/courts/" data-section="courts" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="courts">Courts</a>
+          </li>
+          <li>
+            <a href="/topics/criminal-justice/" data-section="criminal-justice" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="criminal justice">Criminal justice</a>
+          </li>
+          <li>
+            <a href="/topics/demographics/" data-section="demographics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="demographics">Demographics</a>
+          </li>
+          <li>
+            <a href="/topics/economy/" data-section="economy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="economy">Economy</a>
+          </li>
+          <li>
+            <a href="/topics/energy/" data-section="energy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="energy">Energy</a>
+          </li>
+          <li>
+            <a href="/topics/environment/" data-section="environment" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="environment">Environment</a>
+          </li>
+          <li>
+            <a href="/topics/health-care/" data-section="health-care" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="health care">Health care</a>
+          </li>
+          <li>
+            <a href="/topics/higher-education/" data-section="higher-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="higher education">Higher education</a>
+          </li>
+          <li>
+            <a href="/topics/immigration/" data-section="immigration" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="immigration">Immigration</a>
+          </li>
+          <li>
+            <a href="/topics/politics/" data-section="politics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="politics">Politics</a>
+          </li>
+          <li>
+            <a href="/topics/public-education/" data-section="public-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="public education">Public education</a>
+          </li>
+          <li>
+            <a href="/topics/state-government/" data-section="state-government" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="state government">State government</a>
+          </li>
+          <li>
+            <a href="/topics/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="topics">View all</a>
+          </li>
 
-      <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-      <ul class="c-site-footer__links t-size-xs has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg has-text-blue has-text-hover-blue">
-          <a href="https://support.texastribune.org/donate">Donate</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="https://www.texastribune.org/contact/">Contact Us</a>
-        </li>
-        <li>&copy; 2019 The Texas Tribune</li>
-      </ul>
+        </ul>
+      </section>
+      <section class="c-site-footer__col c-site-footer__col--3">
+        <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
+          <span class="is-sr-only">Company </span>Info</h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a href="/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
+          </li>
+          <li>
+            <a href="/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
+          </li>
+          <li>
+            <a href="/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
+          </li>
+          <li>
+            <a href="/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
+          </li>
+          <li>
+            <a href="/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
+          </li>
+          <li>
+            <a href="/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
+          </li>
+          <li>
+            <a href="/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
+          </li>
+          <li>
+            <a href="/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
+          </li>
+          <li>
+            <a href="/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
+          </li>
+
+          <li>
+            <a href="/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential tip</a>
+          </li>
+          <li>
+            <a href="/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
+          </li>
+          <li>
+            <a href="/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
+          </li>
+          <li>
+            <a href="/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
+          </li>
+          <li>
+            <a href="/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
+          </li>
+          <li>
+            <a href="/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
+          </li>
+        </ul>
+      </section>
+      <section class="c-site-footer__col c-site-footer__col--4">
+        <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Social Media</h2>
+        <ul class="c-site-footer__links c-site-footer__links--standard">
+          <li>
+            <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#facebook"></use>
+                </svg>
+              </span>Facebook</a>
+          </li>
+          <li>
+            <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#twitter"></use>
+                </svg>
+              </span>Twitter</a>
+          </li>
+          <li>
+            <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#youtube"></use>
+                </svg>
+              </span>YouTube</a>
+          </li>
+          <li>
+            <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#instagram"></use>
+                </svg>
+              </span>Instagram</a>
+          </li>
+          <li>
+            <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#linkedin"></use>
+                </svg>
+              </span>LinkedIn</a>
+          </li>
+          <li>
+            <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external has-xxs-btm-marg l-display-ib" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#reddit"></use>
+                </svg>
+              </span>Reddit</a>
+          </li>
+          <li>
+            <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-s-btm-marg"></div>
+          </li>
+          <li>
+            <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">
+              <span class="c-icon c-icon--baseline c-site-footer__icon">
+                <svg aria-hidden="true">
+                  <use xlink:href="#your-texas"></use>
+                </svg>
+              </span>Join our Facebook Group, This Is Your Texas.
+            </a>
+          </li>
+        </ul>
+      </section>
     </div>
-    <div>
-      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
-      <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg">
-          <a href="#">Foo</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Bar</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Baz</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Hello</a>
-        </li>
-        <li>
-          <a href="#">World</a>
-        </li>
-      </ul>
-    </div>
-    <div>
-      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
-      <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg">
-          <a href="#">Foo</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Bar</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Baz</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">Hello</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <a href="#">World</a>
-        </li>
-      </ul>
-    </div>
-    <div>
-      <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Social Media</h2>
-      <ul class="c-site-footer__links has-b-btm-marg has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#facebook"></use>
-            </svg>
-          </span>
-          <a href="http://facebook.com/texastribune">Facebook</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#twitter"></use>
-            </svg>
-          </span>
-          <a href="http://twitter.com/texastribune">Twitter</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#youtube"></use>
-            </svg>
-          </span>
-          <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1">YouTube</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#instagram"></use>
-            </svg>
-          </span>
-          <a href="http://instagram.com/texas_tribune">Instagram</a>
-        </li>
-        <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#linkedin"></use>
-            </svg>
-          </span>
-          <a href="http://www.linkedin.com/company/texas-tribune">LinkedIn</a>
-        </li>
-        <li>
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-            <svg aria-hidden="true">
-              <use xlink:href="#reddit"></use>
-            </svg>
-          </span>
-          <a href="https://www.reddit.com/user/texastribune">Reddit</a>
-        </li>
-      </ul>
+  </footer>
+{% endif %}
 
-      <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
-
-      <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li>
-          <a href="https://www.facebook.com/groups/thisisyourtexas/">
-            <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#your-texas"></use>
-              </svg>
-            </span>
-              Join our Facebook Group, This Is Your Texas.
-          </a>
-        </li>
-      </ul>
-    </div>
-  </div>
-</div>-->
-
-<footer id="site_footer" class="c-site-footer has-bg-black-off has-text-white t-size-s">
-  <div class="l-container l-container--xl grid_container--xl c-site-footer__inner">
-    <div class="c-site-footer__col c-site-footer__col--1">
-      <span class="c-site-footer__logo l-display-block">
-        <svg class="l-width-full" aria-hidden="true" viewBox="0 0 139 121" version="1.1" xmlns="http://www.w3.org/2000/svg">
-          <g fill-rule="nonzero" stroke="none" stroke-width="1" fill="none">
-            <path fill="#FFC200" d="M49.09.09l37.09 49.87 7.98-20.65 7.78 20.64 22.03 1.02-17.22 13.78 6.23 21.23L139 120.97V.09z"></path>
-            <path fill="#D39811" d="M94.16 73.89L75.73 86.02l5.84-21.27-17.22-13.78 21.83-1.01L49.09.09v120.88H139l-26.02-34.99z"></path>
-            <path fill="#FFC200" d="M.88.09L19.57 28.6v92.37h29.52V.09z"></path>
-          </g>
-        </svg>
-      </span>
-      <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-b-btm-marg"></div>
-      <ul class="c-site-footer__links">
-        <li class="has-text-blue">
-          <!-- Default -->
-          <a href="https://support.texastribune.org/donate?installmentPeriod=once&amp;amount=60" title="Donate" class="donate" ga-on="click" ga-event-category="donations" ga-event-action="membership-intent" ga-event-label="footer">Donate</a>
-        </li>
-
-        <li>
-          <a href="/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
-        </li>
-        <li>
-          <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
-        </li>
-        <li>
-          <a href="/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">© 2020 The Texas Tribune</a>
-        </li>
-      </ul>
-    </div>
-    <section id="footer-sections" class="c-site-footer__col--2 hide_until--s is-hidden-until-bp-s">
-      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
-        Topics
-      </h2>
-      <ul class="c-site-footer__links">
-        <li>
-          <a href="/topics/congress/" data-section="congress" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="congress">Congress</a>
-        </li>
-        <li>
-          <a href="/topics/courts/" data-section="courts" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="courts">Courts</a>
-        </li>
-        <li>
-          <a href="/topics/criminal-justice/" data-section="criminal-justice" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="criminal justice">Criminal justice</a>
-        </li>
-        <li>
-          <a href="/topics/demographics/" data-section="demographics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="demographics">Demographics</a>
-        </li>
-        <li>
-          <a href="/topics/economy/" data-section="economy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="economy">Economy</a>
-        </li>
-        <li>
-          <a href="/topics/energy/" data-section="energy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="energy">Energy</a>
-        </li>
-        <li>
-          <a href="/topics/environment/" data-section="environment" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="environment">Environment</a>
-        </li>
-        <li>
-          <a href="/topics/health-care/" data-section="health-care" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="health care">Health care</a>
-        </li>
-        <li>
-          <a href="/topics/higher-education/" data-section="higher-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="higher education">Higher education</a>
-        </li>
-        <li>
-          <a href="/topics/immigration/" data-section="immigration" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="immigration">Immigration</a>
-        </li>
-        <li>
-          <a href="/topics/politics/" data-section="politics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="politics">Politics</a>
-        </li>
-        <li>
-          <a href="/topics/public-education/" data-section="public-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="public education">Public education</a>
-        </li>
-        <li>
-          <a href="/topics/state-government/" data-section="state-government" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="state government">State government</a>
-        </li>
-        <li>
-          <a href="/topics/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="topics">View all</a>
-        </li>
-
-      </ul>
-    </section>
-    <section class="c-site-footer__col c-site-footer__col--3">
-      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
-        <span class="is-sr-only">Company </span>Info</h2>
-      <ul class="c-site-footer__links">
-        <li>
-          <a href="/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
-        </li>
-        <li>
-          <a href="/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
-        </li>
-        <li>
-          <a href="/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
-        </li>
-        <li>
-          <a href="/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
-        </li>
-        <li>
-          <a href="/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
-        </li>
-        <li>
-          <a href="/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
-        </li>
-        <li>
-          <a href="/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
-        </li>
-        <li>
-          <a href="/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
-        </li>
-        <li>
-          <a href="/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
-        </li>
-
-        <li>
-          <a href="/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential tip</a>
-        </li>
-        <li>
-          <a href="/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
-        </li>
-        <li>
-          <a href="/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
-        </li>
-        <li>
-          <a href="/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
-        </li>
-        <li>
-          <a href="/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
-        </li>
-        <li>
-          <a href="/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
-        </li>
-      </ul>
-    </section>
-    <section class="c-site-footer__col c-site-footer__col--4">
-      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Social Media</h2>
-      <ul class="c-site-footer__links">
-        <li>
-          <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#facebook"></use>
-              </svg>
-            </span>
-Facebook</a>
-        </li>
-        <li>
-          <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#twitter"></use>
-              </svg>
-            </span>
-Twitter</a>
-        </li>
-        <li>
-          <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#youtube"></use>
-              </svg>
-            </span>
-YouTube</a>
-        </li>
-        <li>
-          <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#instagram"></use>
-              </svg>
-            </span>
-Instagram</a>
-        </li>
-        <li>
-          <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#linkedin"></use>
-              </svg>
-            </span>
-LinkedIn</a>
-        </li>
-        <li>
-          <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external has-xxs-btm-marg l-display-ib" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#reddit"></use>
-              </svg>
-            </span>
-Reddit</a>
-        </li>
-        <li>
-          <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-s-btm-marg"></div>
-        </li>
-        <li>
-          <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">
-            <span class="c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true">
-                <use xlink:href="#your-texas"></use>
-              </svg>
-            </span>
-Join our Facebook Group, This Is Your Texas.</a>
-        </li>
-      </ul>
-    </section>
-  </div>
-</footer>

--- a/assets/scss/6-components/site-footer/site-footer.html
+++ b/assets/scss/6-components/site-footer/site-footer.html
@@ -1,10 +1,9 @@
-<div class="c-site-footer has-bg-black-off">
-  <!--
+  <!--<div class="c-site-footer has-bg-black-off has-giant-btm-marg">
+
     Our various sites will have different variations on the footer
     with different links, number of columns, etc. You'll likely need
     to implement a grid system at the app level to handle those scenarios.
-  -->
-  <div class="c-site-footer__inner l-container l-container--xl t-size-xs">
+<div class="c-site-footer__inner l-container l-container--xl t-size-xs">
     <div>
       <div class="has-b-btm-marg">
         <span style="font-size: 4rem;" class="c-icon has-text-yellow">
@@ -16,56 +15,104 @@
 
       <div class="has-notch has-notch--thin has-bg-yellow has-b-btm-marg" aria-hidden="true"></div>
       <ul class="c-site-footer__links t-size-xs has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg has-text-blue has-text-hover-blue"><a href="https://support.texastribune.org/donate">Donate</a></li>
-        <li class="has-tiny-btm-marg"><a href="https://www.texastribune.org/contact/">Contact Us</a></li>
+        <li class="has-tiny-btm-marg has-text-blue has-text-hover-blue">
+          <a href="https://support.texastribune.org/donate">Donate</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="https://www.texastribune.org/contact/">Contact Us</a>
+        </li>
         <li>&copy; 2019 The Texas Tribune</li>
       </ul>
     </div>
     <div>
       <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
-        <li><a href="#">World</a></li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Foo</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Bar</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Baz</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Hello</a>
+        </li>
+        <li>
+          <a href="#">World</a>
+        </li>
       </ul>
     </div>
     <div>
       <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Heading</h2>
       <ul class="c-site-footer__links has-text-white has-text-hover-white">
-        <li class="has-tiny-btm-marg"><a href="#">Foo</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Bar</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Baz</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">Hello</a></li>
-        <li class="has-tiny-btm-marg"><a href="#">World</a></li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Foo</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Bar</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Baz</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">Hello</a>
+        </li>
+        <li class="has-tiny-btm-marg">
+          <a href="#">World</a>
+        </li>
       </ul>
     </div>
     <div>
       <h2 class="c-site-footer__header has-text-yellow t-uppercase has-xs-btm-marg t-size-xs">Social Media</h2>
       <ul class="c-site-footer__links has-b-btm-marg has-text-white has-text-hover-white">
         <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#facebook"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#facebook"></use>
+            </svg>
+          </span>
           <a href="http://facebook.com/texastribune">Facebook</a>
         </li>
         <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#twitter"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#twitter"></use>
+            </svg>
+          </span>
           <a href="http://twitter.com/texastribune">Twitter</a>
         </li>
         <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#youtube"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#youtube"></use>
+            </svg>
+          </span>
           <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1">YouTube</a>
         </li>
         <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#instagram"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#instagram"></use>
+            </svg>
+          </span>
           <a href="http://instagram.com/texas_tribune">Instagram</a>
         </li>
         <li class="has-tiny-btm-marg">
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#linkedin"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#linkedin"></use>
+            </svg>
+          </span>
           <a href="http://www.linkedin.com/company/texas-tribune">LinkedIn</a>
         </li>
         <li>
-          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon"><svg aria-hidden="true"><use xlink:href="#reddit"></use></svg></span>
+          <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
+            <svg aria-hidden="true">
+              <use xlink:href="#reddit"></use>
+            </svg>
+          </span>
           <a href="https://www.reddit.com/user/texastribune">Reddit</a>
         </li>
       </ul>
@@ -76,11 +123,220 @@
         <li>
           <a href="https://www.facebook.com/groups/thisisyourtexas/">
             <span class="t-size-s c-icon c-icon--baseline c-site-footer__icon">
-              <svg aria-hidden="true"><use xlink:href="#your-texas"></use></svg></span>
+              <svg aria-hidden="true">
+                <use xlink:href="#your-texas"></use>
+              </svg>
+            </span>
               Join our Facebook Group, This Is Your Texas.
           </a>
         </li>
       </ul>
     </div>
   </div>
-</div>
+</div>-->
+
+<footer id="site_footer" class="c-site-footer has-bg-black-off has-text-white t-size-s">
+  <div class="l-container l-container--xl grid_container--xl c-site-footer__inner">
+    <div class="c-site-footer__col c-site-footer__col--1">
+      <span class="c-site-footer__logo l-display-block">
+        <svg class="l-width-full" aria-hidden="true" viewBox="0 0 139 121" version="1.1" xmlns="http://www.w3.org/2000/svg">
+          <g fill-rule="nonzero" stroke="none" stroke-width="1" fill="none">
+            <path fill="#FFC200" d="M49.09.09l37.09 49.87 7.98-20.65 7.78 20.64 22.03 1.02-17.22 13.78 6.23 21.23L139 120.97V.09z"></path>
+            <path fill="#D39811" d="M94.16 73.89L75.73 86.02l5.84-21.27-17.22-13.78 21.83-1.01L49.09.09v120.88H139l-26.02-34.99z"></path>
+            <path fill="#FFC200" d="M.88.09L19.57 28.6v92.37h29.52V.09z"></path>
+          </g>
+        </svg>
+      </span>
+      <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-b-btm-marg"></div>
+      <ul class="c-site-footer__links">
+        <li class="has-text-blue">
+          <!-- Default -->
+          <a href="https://support.texastribune.org/donate?installmentPeriod=once&amp;amount=60" title="Donate" class="donate" ga-on="click" ga-event-category="donations" ga-event-action="membership-intent" ga-event-label="footer">Donate</a>
+        </li>
+
+        <li>
+          <a href="/contact/" title="Contact Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="contact us">Contact Us</a>
+        </li>
+        <li>
+          <a href="https://mediakit.texastribune.org/" title="Advertise" class="advertise" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="advertise">Advertise</a>
+        </li>
+        <li>
+          <a href="/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="copyright">© 2020 The Texas Tribune</a>
+        </li>
+      </ul>
+    </div>
+    <section id="footer-sections" class="c-site-footer__col--2 hide_until--s is-hidden-until-bp-s">
+      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
+        Topics
+      </h2>
+      <ul class="c-site-footer__links">
+        <li>
+          <a href="/topics/congress/" data-section="congress" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="congress">Congress</a>
+        </li>
+        <li>
+          <a href="/topics/courts/" data-section="courts" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="courts">Courts</a>
+        </li>
+        <li>
+          <a href="/topics/criminal-justice/" data-section="criminal-justice" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="criminal justice">Criminal justice</a>
+        </li>
+        <li>
+          <a href="/topics/demographics/" data-section="demographics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="demographics">Demographics</a>
+        </li>
+        <li>
+          <a href="/topics/economy/" data-section="economy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="economy">Economy</a>
+        </li>
+        <li>
+          <a href="/topics/energy/" data-section="energy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="energy">Energy</a>
+        </li>
+        <li>
+          <a href="/topics/environment/" data-section="environment" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="environment">Environment</a>
+        </li>
+        <li>
+          <a href="/topics/health-care/" data-section="health-care" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="health care">Health care</a>
+        </li>
+        <li>
+          <a href="/topics/higher-education/" data-section="higher-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="higher education">Higher education</a>
+        </li>
+        <li>
+          <a href="/topics/immigration/" data-section="immigration" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="immigration">Immigration</a>
+        </li>
+        <li>
+          <a href="/topics/politics/" data-section="politics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="politics">Politics</a>
+        </li>
+        <li>
+          <a href="/topics/public-education/" data-section="public-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="public education">Public education</a>
+        </li>
+        <li>
+          <a href="/topics/state-government/" data-section="state-government" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="state government">State government</a>
+        </li>
+        <li>
+          <a href="/topics/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="topics">View all</a>
+        </li>
+
+      </ul>
+    </section>
+    <section class="c-site-footer__col c-site-footer__col--3">
+      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">
+        <span class="is-sr-only">Company </span>Info</h2>
+      <ul class="c-site-footer__links">
+        <li>
+          <a href="/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
+        </li>
+        <li>
+          <a href="/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
+        </li>
+        <li>
+          <a href="/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
+        </li>
+        <li>
+          <a href="/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
+        </li>
+        <li>
+          <a href="/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
+        </li>
+        <li>
+          <a href="/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
+        </li>
+        <li>
+          <a href="/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
+        </li>
+        <li>
+          <a href="/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
+        </li>
+        <li>
+          <a href="/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
+        </li>
+
+        <li>
+          <a href="/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential tip</a>
+        </li>
+        <li>
+          <a href="/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
+        </li>
+        <li>
+          <a href="/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
+        </li>
+        <li>
+          <a href="/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
+        </li>
+        <li>
+          <a href="/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
+        </li>
+        <li>
+          <a href="/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
+        </li>
+      </ul>
+    </section>
+    <section class="c-site-footer__col c-site-footer__col--4">
+      <h2 class="c-site-footer__header t-size-xs has-text-yellow t-uppercase has-xxs-btm-marg">Social Media</h2>
+      <ul class="c-site-footer__links">
+        <li>
+          <a href="http://facebook.com/texastribune" title="Facebook" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="facebook">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#facebook"></use>
+              </svg>
+            </span>
+Facebook</a>
+        </li>
+        <li>
+          <a href="http://twitter.com/texastribune" title="Twitter" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="twitter">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#twitter"></use>
+              </svg>
+            </span>
+Twitter</a>
+        </li>
+        <li>
+          <a href="http://youtube.com/user/thetexastribune?sub_confirmation=1" title="YouTube" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="youtube">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#youtube"></use>
+              </svg>
+            </span>
+YouTube</a>
+        </li>
+        <li>
+          <a href="http://instagram.com/texas_tribune" title="Instagram" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="instagram">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#instagram"></use>
+              </svg>
+            </span>
+Instagram</a>
+        </li>
+        <li>
+          <a href="http://www.linkedin.com/company/texas-tribune" title="LinkedIn" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="linkedin">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#linkedin"></use>
+              </svg>
+            </span>
+LinkedIn</a>
+        </li>
+        <li>
+          <a href="https://www.reddit.com/user/texastribune" title="Reddit" class="external has-xxs-btm-marg l-display-ib" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="reddit">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#reddit"></use>
+              </svg>
+            </span>
+Reddit</a>
+        </li>
+        <li>
+          <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-s-btm-marg"></div>
+        </li>
+        <li>
+          <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">
+            <span class="c-icon c-icon--baseline c-site-footer__icon">
+              <svg aria-hidden="true">
+                <use xlink:href="#your-texas"></use>
+              </svg>
+            </span>
+Join our Facebook Group, This Is Your Texas.</a>
+        </li>
+      </ul>
+    </section>
+  </div>
+</footer>

--- a/assets/scss/6-components/site-footer/site-footer.html
+++ b/assets/scss/6-components/site-footer/site-footer.html
@@ -117,46 +117,46 @@
         </h2>
         <ul class="c-site-footer__links c-site-footer__links--standard">
           <li>
-            <a href="/topics/congress/" data-section="congress" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="congress">Congress</a>
+            <a href="https://www.texastribune.org/topics/congress/" data-section="congress" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="congress">Congress</a>
           </li>
           <li>
-            <a href="/topics/courts/" data-section="courts" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="courts">Courts</a>
+            <a href="https://www.texastribune.org/topics/courts/" data-section="courts" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="courts">Courts</a>
           </li>
           <li>
-            <a href="/topics/criminal-justice/" data-section="criminal-justice" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="criminal justice">Criminal justice</a>
+            <a href="https://www.texastribune.org/topics/criminal-justice/" data-section="criminal-justice" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="criminal justice">Criminal justice</a>
           </li>
           <li>
-            <a href="/topics/demographics/" data-section="demographics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="demographics">Demographics</a>
+            <a href="https://www.texastribune.org/topics/demographics/" data-section="demographics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="demographics">Demographics</a>
           </li>
           <li>
-            <a href="/topics/economy/" data-section="economy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="economy">Economy</a>
+            <a href="https://www.texastribune.org/topics/economy/" data-section="economy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="economy">Economy</a>
           </li>
           <li>
-            <a href="/topics/energy/" data-section="energy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="energy">Energy</a>
+            <a href="https://www.texastribune.org/topics/energy/" data-section="energy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="energy">Energy</a>
           </li>
           <li>
-            <a href="/topics/environment/" data-section="environment" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="environment">Environment</a>
+            <a href="https://www.texastribune.org/topics/environment/" data-section="environment" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="environment">Environment</a>
           </li>
           <li>
-            <a href="/topics/health-care/" data-section="health-care" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="health care">Health care</a>
+            <a href="https://www.texastribune.org/topics/health-care/" data-section="health-care" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="health care">Health care</a>
           </li>
           <li>
-            <a href="/topics/higher-education/" data-section="higher-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="higher education">Higher education</a>
+            <a href="https://www.texastribune.org/topics/higher-education/" data-section="higher-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="higher education">Higher education</a>
           </li>
           <li>
-            <a href="/topics/immigration/" data-section="immigration" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="immigration">Immigration</a>
+            <a href="https://www.texastribune.org/topics/immigration/" data-section="immigration" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="immigration">Immigration</a>
           </li>
           <li>
-            <a href="/topics/politics/" data-section="politics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="politics">Politics</a>
+            <a href="https://www.texastribune.org/topics/politics/" data-section="politics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="politics">Politics</a>
           </li>
           <li>
-            <a href="/topics/public-education/" data-section="public-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="public education">Public education</a>
+            <a href="https://www.texastribune.org/topics/public-education/" data-section="public-education" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="public education">Public education</a>
           </li>
           <li>
-            <a href="/topics/state-government/" data-section="state-government" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="state government">State government</a>
+            <a href="https://www.texastribune.org/topics/state-government/" data-section="state-government" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="state government">State government</a>
           </li>
           <li>
-            <a href="/topics/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="topics">View all</a>
+            <a href="https://www.texastribune.org/topics/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="topics">View all</a>
           </li>
 
         </ul>
@@ -166,50 +166,50 @@
           <span class="is-sr-only">Company </span>Info</h2>
         <ul class="c-site-footer__links c-site-footer__links--standard">
           <li>
-            <a href="/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
+            <a href="https://www.texastribune.org/about/" title="About Us" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="about us">About Us</a>
           </li>
           <li>
-            <a href="/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
+            <a href="https://www.texastribune.org/about/staff/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="our staff">Our Staff</a>
           </li>
           <li>
-            <a href="/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
+            <a href="https://www.texastribune.org/jobs/" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="jobs">Jobs</a>
           </li>
           <li>
-            <a href="/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
+            <a href="https://www.texastribune.org/support-us/donors-and-members/" title="Who Funds Us?" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="who funds us">Who Funds Us?</a>
           </li>
           <li>
-            <a href="/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
+            <a href="https://www.texastribune.org/about/texas-tribune-strategic-plan/" title="Strategic Plan" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="strategic plan">Strategic Plan</a>
           </li>
           <li>
-            <a href="/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
+            <a href="https://www.texastribune.org/republishing-guidelines/" title="Republishing Guidelines" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="republishing guidelines">Republishing Guidelines</a>
           </li>
           <li>
-            <a href="/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
+            <a href="https://www.texastribune.org/about/ethics/" title="Code of Ethics" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="code of ethics">Code of Ethics</a>
           </li>
           <li>
-            <a href="/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
+            <a href="https://www.texastribune.org/about/terms-of-service/" title="Terms of Service" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="terms of service">Terms of Service</a>
           </li>
           <li>
-            <a href="/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
+            <a href="https://www.texastribune.org/about/privacy-policy/" title="Privacy Policy" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="privacy policy">Privacy Policy</a>
           </li>
 
           <li>
-            <a href="/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential tip</a>
+            <a href="https://www.texastribune.org/about/tips/" title="Send a Tip" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="send us a confidential tip">Send us a confidential tip</a>
           </li>
           <li>
-            <a href="/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
+            <a href="https://www.texastribune.org/corrections/" title="Corrections" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="corrections">Corrections</a>
           </li>
           <li>
-            <a href="/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
+            <a href="https://www.texastribune.org/about/feeds/" title="Feeds" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="feeds">Feeds</a>
           </li>
           <li>
-            <a href="/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
+            <a href="https://www.texastribune.org/about/subscribe/" title="Newsletters" ga-event-category="subscribe intent" ga-event-action="footer link">Newsletters</a>
           </li>
           <li>
-            <a href="/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
+            <a href="https://www.texastribune.org/audio/" title="Audio" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="audio">Audio</a>
           </li>
           <li>
-            <a href="/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
+            <a href="https://www.texastribune.org/video/" title="Video" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="video">Video</a>
           </li>
         </ul>
       </section>
@@ -265,7 +265,7 @@
               </span>Reddit</a>
           </li>
           <li>
-            <div class="border--yellow_notch has-notch has-notch--thin has-bg-yellow has-s-btm-marg"></div>
+            <div class="has-notch has-notch--thin has-bg-yellow has-s-btm-marg"></div>
           </li>
           <li>
             <a href="https://www.facebook.com/groups/thisisyourtexas/" title="This is Your Texas" class="external" ga-event-category="navigation" ga-event-action="footer link click" ga-event-label="this is your texas">
@@ -281,4 +281,3 @@
     </div>
   </footer>
 {% endif %}
-

--- a/docs/src/layouts/base.njk
+++ b/docs/src/layouts/base.njk
@@ -10,7 +10,6 @@ title: Queso UI - CSS + HTML Guide for The Texas Tribune
     <link rel="stylesheet" type="text/css" href="https://cdn.jsdelivr.net/npm/bulma@0.8.2/css/bulma.min.css"/>
     <link rel="stylesheet" type="text/css" href="{{ '/css/queso-docs.css' | url }}">
     <link rel="stylesheet" type="text/css" href="{{ '/css/all.css' | url }}">
-    <link rel="stylesheet" type="text/css" href="{{ '/css/code.css' | url }}">
   </head>
   <body>
     <div style="display: none">{% include "../../dist/sprites/docs.html" %}</div>

--- a/docs/src/layouts/example-base.njk
+++ b/docs/src/layouts/example-base.njk
@@ -3,8 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block name %}TEST{% endblock %}</title>
-  <meta name="description" content="TEST">
+  <title>{{ title }} | Queso UI</title>
+  <meta name="description" content="This is a preview of {{ title }}">
   <link rel="stylesheet" type="text/css" href="{{ '/css/all.css' | url }}">
 </head>
 <body style="padding-bottom: 10px;">

--- a/docs/src/layouts/example-base.njk
+++ b/docs/src/layouts/example-base.njk
@@ -3,7 +3,8 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{% block name %}{% endblock %}</title>
+  <title>{% block name %}TEST{% endblock %}</title>
+  <meta name="description" content="TEST">
   <link rel="stylesheet" type="text/css" href="{{ '/css/all.css' | url }}">
 </head>
 <body style="padding-bottom: 10px;">

--- a/docs/src/pages/example-modifier.njk
+++ b/docs/src/pages/example-modifier.njk
@@ -5,6 +5,7 @@ pagination:
     size: 1
     alias: modifier
 permalink: "modifier/{{ modifier.className }}/"
+title: Preview modifier
 ---
 {% block content %}
   {% if modifier.modifierSnippet %}

--- a/docs/src/pages/example.njk
+++ b/docs/src/pages/example.njk
@@ -5,6 +5,7 @@ pagination:
     size: 1
     alias: item
 permalink: "example/{{ item.slug }}/"
+title: Preview
 ---
 {% block content %}
   {% if item.codeSnippet and not item.isHelper %}


### PR DESCRIPTION
#### What's this PR do?
Adds a new variation of the site footer to the docs with two columns on mobile instead of three

##### Classes added (if any)
- .c-site-footer__inner--standard
- .c-site-footer__links--standard

#### Why are we doing this? How does it help us?

To make our footer more mobile-friendly ([according to Google](https://web.dev/tap-targets/) 🤷‍♀️ )

The mobile layout I had to add to fix our lighthouse score is a little complicated. That got me thinking that we may just want to build it in as a variation to prevent having to copy/paste it everywhere the standard footer is used, which is a growing number of repos.


#### How should this be manually tested?
`npm run dev`

See: [The "standard" site footer](localhost:8080/modifier/c-site-footer__inner--standard/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

The donations account page footer will get a few more styles than it actually needs, but that seems fine to me. Everywhere else, we'll be able to delete some of the repo-specific CSS.


The point of this is to fix our small tap targets flagged in lighthouse, so for that reason I'm thinking that's considered a patch

