### PR TITLE
Fix broken previews in docs

### DIFF
--- a/docs/src/macros/toggle-view.njk
+++ b/docs/src/macros/toggle-view.njk
@@ -1,6 +1,6 @@
 {% macro toggleView(path, item, githubData) %}
   {% from "../macros/data-list.njk" import dataList %}
-  {% set id = item.className %}
+  {% set id = item.className|lower %}
   {% set previewUrl = '/' + path  + '/' + id %}
   <div id="{{ id }}-display" class="q-display-col">
     <div id="{{ id }}-buttons" class="q-display-buttons buttons are-small">


### PR DESCRIPTION


#### What's this PR do?

Fixes these broken previews for "recipe" docs
![Screen Shot 2020-10-13 at 9 00 24 AM](https://user-images.githubusercontent.com/2974713/95870812-8d97e500-0d32-11eb-98c7-03fe2a306f84.png)
##### Classes added (if any)
None
##### Classes removed (if any)
None


#### Why are we doing this? How does it help us?
Better docs


#### How should this be manually tested?
`npm run dev`

See: [kicker](http://localhost:8080/sections/typography/kicker/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

No release needed; this is a docs change only



