### PR TITLE
Remove arrow-list style

### DIFF
--- a/assets/scss/6-components/list/_list.scss
+++ b/assets/scss/6-components/list/_list.scss
@@ -2,8 +2,6 @@
 //
 // Our standard list is just plain ol' bullets
 //
-// .c-list--arrows - Sometimes we add little SVG bullets
-//
 // Markup: 6-components/list/list.html
 //
 // Styleguide 6.1.3
@@ -12,31 +10,5 @@
 
   li {
     list-style: disc;
-  }
-
-  &--arrows {
-    li {
-      list-style: none;
-      position: relative;
-
-      &:before {
-        background-image: url('data:image/svg+xml;utf8,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 28"><path fill="rgb(208,208,208)" d="M9 14c0 0.266-0.109 0.516-0.297 0.703l-7 7c-0.187 0.187-0.438 0.297-0.703 0.297-0.547 0-1-0.453-1-1v-14c0-0.547 0.453-1 1-1 0.266 0 0.516 0.109 0.703 0.297l7 7c0.187 0.187 0.297 0.438 0.297 0.703z"></path></svg>');
-        background-position: center center;
-        background-repeat: no-repeat;
-        background-size: $size-xs $size-xs;
-        content: '';
-        height: $size-xs;
-        left: -$size-b;
-        margin-top: 6px;
-        position: absolute;
-        width: $size-xs;
-      }
-
-      &:hover {
-        &:before {
-          background-image: url('data:image/svg+xml;utf8,<svg version="1.1" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 9 28"><path fill="rgb(255,194,0)" d="M9 14c0 0.266-0.109 0.516-0.297 0.703l-7 7c-0.187 0.187-0.438 0.297-0.703 0.297-0.547 0-1-0.453-1-1v-14c0-0.547 0.453-1 1-1 0.266 0 0.516 0.109 0.703 0.297l7 7c0.187 0.187 0.297 0.438 0.297 0.703z"></path></svg>');
-        }
-      }
-    }
   }
 }

--- a/assets/scss/6-components/list/_list.scss
+++ b/assets/scss/6-components/list/_list.scss
@@ -10,5 +10,13 @@
 
   li {
     list-style: disc;
+
+    &::marker {
+      color: $color-gray-medium;
+    }
+
+    &:hover::marker {
+      color: $color-yellow-tribune;
+    }
   }
 }

--- a/assets/scss/6-components/list/list.html
+++ b/assets/scss/6-components/list/list.html
@@ -1,4 +1,4 @@
-<ul class="c-list {{className}}">
+<ul class="c-list">
   <li>Bacon</li>
   <li>Eggs</li>
   <li>Cheese</li>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "9.5.0-0",
+  "version": "9.5.0-1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "9.4.2",
+  "version": "9.5.0-0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "9.4.2",
+  "version": "9.5.0-0",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@texastribune/queso-ui",
-  "version": "9.5.0-0",
+  "version": "9.5.0-1",
   "description": "Asset library of SCSS and SVG files",
   "scripts": {
     "prettier": "prettier --write './docs/**/*.js'",


### PR DESCRIPTION
#### What's this PR do?
Kill `c-list--arrows`

##### Classes removed (if any)
- `c-list--arrows`

#### Why are we doing this? How does it help us?
Art-team recommendation. It started with cutting this style from the home-page series module and is now ending with getting rid of it entirely.

#### How should this be manually tested?
Confirm the example of `c-list` looks OK and has bullets.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
This will be a minor release.