### PR TITLE
Always give tabs a pointer cursor

### DIFF
--- a/assets/scss/6-components/tabs/_tabs.scss
+++ b/assets/scss/6-components/tabs/_tabs.scss
@@ -11,7 +11,7 @@
   flex-wrap: wrap;
   list-style: none;
   border-bottom: 5px solid $color-yellow-tribune;
-  
+
   &__tab {
     &--wide {
       flex: 0 1 10rem;
@@ -21,6 +21,7 @@
   &__link {
     background-color: $color-black-off;
     color: $color-white-pure;
+    cursor: pointer;
     display: block;
     border-right: 2px solid #fff;
     padding: $size-s;
@@ -43,7 +44,7 @@
 .c-tab-panes {
   &__pane {
     display: none;
-    
+
     &--active {
       display: block;
     }


### PR DESCRIPTION
#### What's this PR do?

See title

##### Classes added (if any)
None
##### Classes removed (if any)
None

#### Why are we doing this? How does it help us?

The tabs styles assume that tabs will be `<a>` tags, but I recently implemented tabs on the republish page where we're set up to use buttons. It made me realize, we should probably force the pointer cursor as an indicator for those being clickable elements.

#### How should this be manually tested?
`npm run dev`

See: [tabs](http://localhost:8080/sections/components/c-tabs/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope, just a patch IMO

