### PR TITLE
Scope out directory components

### DIFF
--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -59,7 +59,7 @@
 // Styleguide 2.1.3
 //
 @mixin underlined-link-parent($hover-only: false) {
-  a {
+  a:not(.t-links-unset) {
     @include underlined-link($hover-only);
   }
 }
@@ -117,4 +117,33 @@
 @mixin col-gap($size: $size-b) {
   grid-column-gap: $size;
   column-gap: $size;
+}
+
+// @mixin color-classes
+//
+// Generate color helper classes based on a [map](https://sass-lang.com/documentation/values/maps)
+//
+// $color-map = '' - {Sass map} Ex: $color-map: ("black": $color-black-pure)
+// $type = '' - {String} Either 'bg', 'text' or 'text-hover'
+//
+// Styleguide 2.1.3
+//
+@mixin color-classes($color-map, $type) {
+  $property: 'color';
+  @if ($type == 'bg') {
+    $property:'background-color';
+  }
+  @each $color, $value in $color-map {
+    @if ($type == 'text-hover') {
+      .has-#{$type}-#{$color}:hover,
+      .has-#{$type}-#{$color}:active {
+        #{$property}: $value;
+      }
+    } @else {
+      /* #{$value} */
+      .has-#{$type}-#{$color} {
+        #{$property}: $value;
+      }
+    }
+  }
 }

--- a/assets/scss/2-tools/_mixins.scss
+++ b/assets/scss/2-tools/_mixins.scss
@@ -123,8 +123,11 @@
 //
 // Generate color helper classes based on a [map](https://sass-lang.com/documentation/values/maps)
 //
-// $color-map = '' - {Sass map} Ex: $color-map: ("black": $color-black-pure)
-// $type = '' - {String} Either 'bg', 'text' or 'text-hover'
+// `$my-map: ('purple': rebeccapurple, 'blue': dodgerblue)`<br>
+// `@include($my-map, 'bg')`
+//
+// $color-map = '' - A sass map variable (required)
+// $type = '' - Either 'bg', 'text' or 'text-hover' (required)
 //
 // Styleguide 2.1.3
 //

--- a/assets/scss/5-typography/_links.scss
+++ b/assets/scss/5-typography/_links.scss
@@ -6,13 +6,14 @@
 // .t-links-underlined - Typical blue underlined links
 // .t-links-underlined-hover - Underline only appears on hover
 // .t-links-underlined-hover-thin - Smaller, browser-default underline on hover
+// .t-links-unset - This is applied **directly to the `<a>` tag**. Use it in cases where you don't want to inherit link styles.
 //
-// Markup: <p class="{{ className }}">Block of text in a paragraph. <a href="https://www.texastribune.org/">This is what links with a parent of {{ className }} look like.</a></p>
+// Markup: <p class="{{ className }}">Block of text in a paragraph. <a href="https://www.texastribune.org/">Example of {{ className }}.</a></p>
 //
 // Styleguide 5.2.8
 //
 .t-links {
-  a {
+  a:not(.t-links-unset) {
     color: $color-teal-gray;
     font-weight: bold;
   }

--- a/assets/scss/6-components/_all.scss
+++ b/assets/scss/6-components/_all.scss
@@ -32,6 +32,7 @@
 @import 'story-body/story-body';
 @import 'table/table';
 @import 'tabs/tabs';
+@import 'tag/tag';
 @import 'text-input/text-input';
 @import 'topic-bar/topic-bar';
 @import 'widget/widget';

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -6,7 +6,7 @@
 // .c-button--l - Uses size-l for font size and padding
 // .c-button--s - One step down from default
 // .c-button--xs - Two steps down from default
-// .c-button--circle - Circular button
+// .c-button--circle - Fixed height and width button paired with `is-rounded-full`
 // .c-button--outline - Hover effect of outline (used on social)
 // .c-button--skip - Visible only on focus, this is used to skip navigation
 //

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -6,7 +6,7 @@
 // .c-button--l - Uses size-l for font size and padding
 // .c-button--s - One step down from default
 // .c-button--xs - Two steps down from default
-// .c-button--circle - Circular button (experimentally used for back to top)
+// .c-button--circle - Circular button
 // .c-button--outline - Hover effect of outline (used on social)
 // .c-button--skip - Visible only on focus, this is used to skip navigation
 //
@@ -64,7 +64,6 @@
   }
 
   &--circle {
-    border-radius: 50%;
     width: 4rem;
     height: 4rem;
     position: relative;

--- a/assets/scss/6-components/button/button.html
+++ b/assets/scss/6-components/button/button.html
@@ -1,7 +1,6 @@
 
-{% if className === 'c-button--circle' or className === 'c-button--circle-responsive' %}
-Use with vertical centering helper. <code>.l-align-center-y</code>
-<button class="c-button {{ className }}">
+{% if className === 'c-button--circle' %}
+<button class="c-button {{ className }} is-rounded-full">
     <span class="l-align-center-y t-size-xxs"><span class="c-icon c-icon--arrow-up l-display-block"><svg aria-hidden="true">
         <use xlink:href="#arrow-up"></use>
     </svg></span>Back to Top</span>

--- a/assets/scss/6-components/tag/_tag.scss
+++ b/assets/scss/6-components/tag/_tag.scss
@@ -2,7 +2,7 @@
 //
 // Tags can be used to label or categorize items. They're designed to scale according to their inherited font size using `em`s.
 //
-// .c-tag--fixed - Has a set height and width, which responds to font-size. Use with `is-rounded-full` to create a circle.
+// .c-tag--fixed - Has a set height and width, which responds to font-size. Use with `is-rounded-full` to create a circle. *A11y note:* Pay particular attention to the use of `.is-sr-only`, `aria-hidden`, and `title=` to convey meaning to obscure, one letter tags in the HTML of the example.
 //
 // Markup: 6-components/tag/tag.html
 //

--- a/assets/scss/6-components/tag/_tag.scss
+++ b/assets/scss/6-components/tag/_tag.scss
@@ -1,0 +1,25 @@
+// Tag (c-tag)
+//
+// Tags can be used to label or categorize items. They're designed to scale to a parent container's font-size.
+//
+// .c-tag--fixed - Has a set height and width, which responds to font-size. Use with `is-rounded-full` to create a circle.
+//
+// Markup: 6-components/tag/tag.html
+//
+// Styleguide 6.0.1
+.c-tag {
+  display: inline-flex;
+  justify-content: center;
+  align-items: center;
+  padding: $size-tiny;
+
+  &--fixed {
+    padding: 0;
+    height: 1.5em;
+    width: 1.5em;
+  }
+
+  &__inner {
+    font-size: .92em;
+  }
+}

--- a/assets/scss/6-components/tag/_tag.scss
+++ b/assets/scss/6-components/tag/_tag.scss
@@ -1,6 +1,6 @@
 // Tag (c-tag)
 //
-// Tags can be used to label or categorize items. They're designed to scale to a parent container's font-size.
+// Tags can be used to label or categorize items. They're designed to scale according to their inherited font size using `em`s.
 //
 // .c-tag--fixed - Has a set height and width, which responds to font-size. Use with `is-rounded-full` to create a circle.
 //

--- a/assets/scss/6-components/tag/tag.html
+++ b/assets/scss/6-components/tag/tag.html
@@ -1,9 +1,15 @@
 {% if className === 'c-tag--fixed' %}
-<p class="has-b-btm-marg t-size-s">Jerry Seinfeld <span class="c-tag c-tag--fixed has-bg-ind has-text-white"><span class="c-tag__inner">I</span></span></p>
-<p class="has-b-btm-marg t-size-s"><strong>Cosmo Kramer <span class="c-tag c-tag--fixed has-bg-lib is-rounded-full"><span class="c-tag__inner">L</span></span></strong></p>
+<p class="has-b-btm-marg t-size-s">
+  Jerry Seinfeld <span class="is-sr-only">Libertarian party</span><span class="c-tag c-tag--fixed has-bg-lib is-rounded-full" title="Libertarian party" aria-hidden="true"><span class="c-tag__inner">L</span></span>
+</p>
+<p class="has-b-btm-marg t-size-s">
+  <strong>
+  Cosmo Kramer <span class="is-sr-only">Independent party</span><span class="c-tag c-tag--fixed has-bg-ind has-text-white is-rounded-full" title="Independent party" aria-hidden="true"><span class="c-tag__inner">I</span></span>
+  </strong>
+</p>
 
 Append <code>.t-size-&lt;any-size&gt;</code> to vary the tag size.
-<span class="t-size-m c-tag c-tag--fixed has-bg-rep has-text-white is-rounded-full"><span class="c-tag__inner"><strong>R</strong></span></span>
+<span class="t-size-m c-tag c-tag--fixed has-bg-rep has-text-white is-rounded-full" aria-hidden="true"><span class="c-tag__inner"><strong>R</strong></span></span>
 
 
 {% else %}

--- a/assets/scss/6-components/tag/tag.html
+++ b/assets/scss/6-components/tag/tag.html
@@ -1,0 +1,28 @@
+{% if className === 'c-tag--fixed' %}
+<p class="has-b-btm-marg t-size-s">Jerry Seinfeld <span class="c-tag c-tag--fixed has-bg-ind has-text-white"><span class="c-tag__inner">I</span></span></p>
+<p class="has-b-btm-marg t-size-s"><strong>Cosmo Kramer <span class="c-tag c-tag--fixed has-bg-lib is-rounded-full"><span class="c-tag__inner">L</span></span></strong></p>
+
+Append <code>.t-size-&lt;any-size&gt;</code> to vary the tag size.
+<span class="t-size-m c-tag c-tag--fixed has-bg-rep has-text-white is-rounded-full"><span class="c-tag__inner"><strong>R</strong></span></span>
+
+
+{% else %}
+<div class="has-b-btm-marg">
+  <span class="c-tag has-bg-gray-dark has-text-white">
+    <span class="c-tag__inner">simple tag</span>
+  </span>
+</div>
+<p class="has-b-btm-marg t-links-underlined">
+  This is a paragraph of text, which includes a <span class="c-tag has-bg-white-off is-rounded-b"><span class="c-tag__inner t-weight-bold">tag</span></span>.
+</p>
+<p class="has-b-btm-marg t-links-underlined">
+  Use tags to highlight topics like <span class="c-tag has-bg-white-off is-rounded-b"><span class="c-tag__inner t-weight-bold">politics</span></span> or <a class="c-tag has-border is-rounded-b t-links-unset" href="#"><span class="c-tag__inner t-weight-bold">#txlege</a></span>.
+<p>
+<p class="has-b-btm-marg">You can also use them to list topics:</p>
+<p>
+  <span class="c-tag has-bg-white-off is-rounded-b"><span class="c-tag__inner t-weight-bold">higher education</span></span>&nbsp;
+  <span class="c-tag has-bg-white-off is-rounded-b"><span class="c-tag__inner t-weight-bold">energy</span></span>&nbsp;
+  <span class="c-tag has-bg-white-off is-rounded-b"><span class="c-tag__inner t-weight-bold">immigration</span></span>&nbsp;
+</p>
+
+{% endif %}

--- a/assets/scss/all.scss
+++ b/assets/scss/all.scss
@@ -10,3 +10,6 @@
 @import '6-components/all';
 @import '7-layout/all';
 @import 'utilities/all';
+
+// optional
+@import 'utilities/color-helpers-parties';

--- a/assets/scss/utilities/_color-helpers-parties.scss
+++ b/assets/scss/utilities/_color-helpers-parties.scss
@@ -1,6 +1,6 @@
 // Political party colors (has-bg-<party>)
 //
-// Optional colors that extend the standard color helpers. They are separated out in order to to enable only adding this utility import when necessary. {{isHelper}}
+// Optional colors that extend the standard color helpers. They're separated from the standard helpers to allow us to import them only when necessary. {{isHelper}}
 //
 // .has-bg-rep - Background color assigned to republicans
 // .has-bg-dem - Background color assigned to democrats

--- a/assets/scss/utilities/_color-helpers-parties.scss
+++ b/assets/scss/utilities/_color-helpers-parties.scss
@@ -1,0 +1,26 @@
+// Political party colors (has-bg-<party>)
+//
+// Optional colors that extend the standard color helpers. They are separated out in order to to enable only adding this utility import when necessary. {{isHelper}}
+//
+// .has-bg-rep - Background color assigned to republicans
+// .has-bg-dem - Background color assigned to democrats
+// .has-bg-lib - Background color assigned to libertarians
+// .has-bg-gre - Background color assigned to green party
+// .has-bg-ind - Background color assigned to independents
+//
+// Markup: <div class="has-padding {{ className }}">Example</div>
+//
+//
+// Styleguide 8.0.1
+//
+
+$political-parties-colors: (
+  "rep": $color-republican,
+  "dem": $color-democrat,
+  "gre": $color-green,
+  "lib": $color-libertarian,
+  "ind": $color-independent
+);
+
+// has-bg-<party>
+@include color-classes($political-parties-colors, 'bg');

--- a/assets/scss/utilities/_color-helpers.scss
+++ b/assets/scss/utilities/_color-helpers.scss
@@ -98,26 +98,12 @@ $color-map: (
   "facebook": $color-facebook,
 );
 
-// bg-color
-@each $color, $value in $color-map {
-  .has-bg-#{$color} {
-    background-color: $value;
-  }
-}
+// has-bg-<color>
+@include color-classes($color-map, 'bg');
 
-// text-hover
-@media (hover: hover) {
-  @each $color, $value in $color-map {
-    .has-text-hover-#{$color}:hover,
-    .has-text-hover-#{$color}:active {
-      color: $value;
-    }
-  }
-}
+// has-text-hover-<color>
+@include color-classes($color-map, 'text-hover');
 
-// text-color
-@each $color, $value in $color-map {
-  .has-text-#{$color} {
-    color: $value;
-  }
-}
+// has-text-<color>
+@include color-classes($color-map, 'text');
+

--- a/assets/scss/utilities/_rounded.scss
+++ b/assets/scss/utilities/_rounded.scss
@@ -2,10 +2,11 @@
 //
 // For roundin' out those corners. {{isHelper}}
 //
-// .is-rounded-b - The base rounded measure `4px`
-// .is-rounded-l - More dramatic rounding of `40px`. (Used for pill buttons in donation CTAs.)
+// .is-rounded-b - `border-radius: 4px` The base rounded measure
+// .is-rounded-l - `border-radius: 40px`. (Used for pill buttons in donation CTAs.)
+// .is-rounded-full - `border-radius: 50%` Used for circles. Works best with a width and height
 //
-// Markup: <div class="{{ className }} has-bg-gray-light has-padding">Bordered</div>
+// Markup: <div class="{{ className }} has-bg-gray-light has-padding" style="width:150px;height:150px"></div>
 //
 //
 // Styleguide 8.0.3
@@ -16,4 +17,8 @@
 
 .is-rounded-l {
   border-radius: 40px;
+}
+
+.is-rounded-full {
+  border-radius: 50%;
 }


### PR DESCRIPTION
#### What's this PR do?

- Adds a new tag component to account for our party-pills
- Cleans up some of the color helper and border-radius docs

##### Classes added (if any)
- c-tag
- c-tag--fixed - For fixed width/height tags
- has-bg-<party> - For bg colors of ^
- is-rounded-full* - For circles
- t-links-unset* - For if tags inherit unwanted link styles
*These is the only ones that will actually show up in global CSS

#### Why are we doing this? How does it help us?

Accounts for styles in the Texas lawmakers directory and maybe some data visuals projects if these could also work for them.

#### How should this be manually tested?
`npm run dev`

- [c-tag](http://localhost:8080/sections/components/c-tag/) - How do you feel about this name, @AndrewGibson27?
I did some, "what do people tend to call these" research (added below) and `tag` seemed to be the most common. It also felt handy that both the name and how it's styled meant it could extend beyond just the use case of the R, D, labels. It is a loaded word for sure though, so I'm not married to it.
- [is-rounded-full](http://localhost:8080/sections/utilities/is-rounded-size/) - Decouples `border-radius: 50%` from the tag so that we could one day use it in other places.
- [has-color-rep, has-color-dem etc.](http://localhost:8080/sections/utilities/has-bg-party/) - Again decouples the bg colors so that we can use them in other places if needed.

#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

So far, no. I will need to go in and add `is-rounded-full` to the back to top button, but that feels like small 🥔 s.


#### TODOs / next steps (probably in a new PR to keep this one small):
* [ ] *Reach out to EA about a more contrasted version of white text on republican red*
* [ ] *~Scope out how lawmaker cards translate in the queso world~* These might make more sense at the repo level on second thought.
* [x] *Add a table variation with sorting*

#### Naming research
- 3 - tag ([Bulma](https://bulma.io/documentation/elements/tag/) | [IBM](https://www.carbondesignsystem.com/components/tag/usage) | [Buzzfeed Solid](https://solid.buzzfeed.com/tags.html))
- 2 - badge ([Bootstrap](https://getbootstrap.com/docs/5.0/components/badge/) | [Polaris Shopify](https://polaris.shopify.com/components/images-and-icons/badge#navigation))
- 1 - label ([Github Primer](https://primer.style/css/components/labels))
- 1 - chip ([Material](https://material.io/components/chips#input-chips)) winner for cutest name tho
