### PR TITLE
Make cursor: pointer default on all button elements

### DIFF
--- a/assets/scss/4-elements/_all.scss
+++ b/assets/scss/4-elements/_all.scss
@@ -46,6 +46,7 @@ cite {
 button {
   background: none;
   border: none;
+  cursor: pointer;
   padding: 0;
 }
 

--- a/assets/scss/6-components/button/_button.scss
+++ b/assets/scss/6-components/button/_button.scss
@@ -17,7 +17,6 @@
   background-color: $color-blue-light;
   border: none;
   border-radius: 0;
-  cursor: pointer;
   font-weight: 700;
   font-size: $size-xs;
   letter-spacing: $font-letter-spacing-b;
@@ -133,6 +132,5 @@
 .c-link-button {
   @include underlined-link;
   color: inherit;
-  cursor: pointer;
   line-height: normal;
 }

--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -86,7 +86,6 @@
   &__clickable {
     align-items: center;
     border: none;
-    cursor: pointer;
     display: flex;
     padding: 0;
     position: relative;

--- a/assets/scss/6-components/tabs/_tabs.scss
+++ b/assets/scss/6-components/tabs/_tabs.scss
@@ -21,7 +21,6 @@
   &__link {
     background-color: $color-black-off;
     color: $color-white-pure;
-    cursor: pointer;
     display: block;
     border-right: 2px solid #fff;
     padding: $size-s;


### PR DESCRIPTION
#### What's this PR do?

Makes `cursor: pointer` default on the `<button>` element


#### Why are we doing this? How does it help us?

I keep finding new places where I need to add `cursor: pointer` to buttons e.g. tabs and the icon button to ascend/descend in table columns. 

As it turns out,  making all buttons have pointers is a bit of a hot take. There's [a thread](https://ux.stackexchange.com/questions/105024/why-dont-button-html-elements-have-a-css-cursor-pointer-by-default) on the internet where people argue about it, but this line won me over in favor of it:

> One of the main tenets of UX is "don't make me think" .... if you don't have a hand pointer over a button then you have to think "is this a button?"



#### How should this be manually tested?

Nothing to test really


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Nope. I'm going to merge this and just let it hang out until the next release. It'll help with a forthcoming table PR which I'll add after the JS refactor of the directory tables.

