### PR TITLE
Allow for table borders on row and cells

### DIFF
--- a/assets/scss/6-components/table/_table.scss
+++ b/assets/scss/6-components/table/_table.scss
@@ -62,10 +62,10 @@
 
   &--bordered {
     border: 1px solid $color-white-off;
-    tr {
+    tbody > tr {
       border-top: 1px solid $color-white-off;
     }
-    td, th {
+    tr > td, tr > th {
       border-left: 1px solid $color-white-off;
     }
   }

--- a/assets/scss/6-components/table/_table.scss
+++ b/assets/scss/6-components/table/_table.scss
@@ -11,10 +11,12 @@
 
 // Table (c-table)
 //
-// Tabular display classes. Tables should be constructed with a <thead> and <tbody>.
+// Tabular display classes. Tables should be constructed with a `<thead>` and `<tbody>`. <br><br>
+// Tip: Use `transform: scaleY(-1);` to flip ascending/descending icons
 //
 // .c-table--striped - Zebra stripes odd rows
-// .c-table--bordered - Bordered rows
+// .c-table--bordered - Bordered table, cells, rows and headings
+// .c-table--bordered-rows - Bordered rows
 // .c-table--10-45-45 - Three-column table with col widths 10%, 45%, 45%
 // .c-table--15-70-15 - Two-column table with col widths 15%, 70%, 15%
 //
@@ -52,9 +54,19 @@
     }
   }
 
-  &--bordered {
+  &--bordered-rows {
     tbody > tr {
       border-top: 1px solid $color-white-off;
+    }
+  }
+
+  &--bordered {
+    border: 1px solid $color-white-off;
+    tr {
+      border-top: 1px solid $color-white-off;
+    }
+    td, th {
+      border-left: 1px solid $color-white-off;
     }
   }
 }

--- a/assets/scss/6-components/table/table.html
+++ b/assets/scss/6-components/table/table.html
@@ -2,7 +2,15 @@
   <thead>
     <tr>
       <th class="t-align-left"><strong>A</strong></th>
-      <th class="t-align-left"><strong>B</strong></th>
+      <th class="t-align-left">
+        <strong>B</strong>
+        <button>
+          <span class="is-sr-only">Sort B by ascending</span>
+          <span class="c-icon c-icon--baseline t-size-xs">
+            <svg aria-hidden="true"><use xlink:href="#caret-down"></use></svg>
+          </span>
+        </button>
+      </th>
       <th class="t-align-left"><strong>C</strong></th>
     </tr>
   </thead>

--- a/assets/scss/6-components/table/table.html
+++ b/assets/scss/6-components/table/table.html
@@ -3,9 +3,8 @@
     <tr>
       <th class="t-align-left"><strong>A</strong></th>
       <th class="t-align-left">
-        <strong>B</strong>
-        <button>
-          <span class="is-sr-only">Sort B by ascending</span>
+        <button title="Sort by B in descending order">
+          <strong>B</strong>
           <span class="c-icon c-icon--baseline t-size-xs">
             <svg aria-hidden="true"><use xlink:href="#caret-down"></use></svg>
           </span>

--- a/contributing.md
+++ b/contributing.md
@@ -31,7 +31,7 @@ When you add a new class, component, scss variable, mixin, etc., you'll want to 
 
 > How to document a new CSS class
 
-We use a comment parser along with some [extra logic](https://github.com/texastribune/queso-ui/blob/main/tasks/style-doc.js) to generate our docs. To add a new section of documentation, add a boilerplate above your CSS rules like the one below: 
+We use a comment parser along with some [extra logic](https://github.com/texastribune/queso-ui/blob/main/tasks/style-doc.js) to generate our docs. To add a new section of documentation, add a boilerplate above your CSS rules like the one below:
 
 ```scss
 // Title of Section (root-class-name)
@@ -116,8 +116,8 @@ The npm helper we use for versioning simplifies matching version numbers with th
 Generally, you could base your increment type on the following list:
 
 - MAJOR version = CSS changes that visually break layouts where `queso-ui` is used on production
-- MINOR version = CSS changes that have no visual effect on production
-- PATCH version = CSS changes that fix a previous bug introduced on production or in development 
+- MINOR version = CSS changes that have subtle or no visual effects on production
+- PATCH version = CSS changes that fix a previous bug introduced on production or in development
 
 #### Steps to test breaking changes:
 


### PR DESCRIPTION
#### What's this PR do?

Right now, the class `c-table--bordered` applies a row (top/bottom) border, but this changes that to apply both row and cell (left/right) borders. 

This also documents the recommended markup for sorted column headers

##### Classes added (if any)
-`.c-table--bordered-rows`- For case where you _just_ want row borders

#### Why are we doing this? How does it help us?

Used for directory

#### How should this be manually tested?
`npm run dev`

See: [c-table](http://localhost:8080/sections/components/c-table/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

I've been sorta walking back on my initial interpretation of what merits a major release. I think instead of anything that introduces a visual _change_, it should be anything that introduces visual _disruption_. In this example, this PR will make [this `c-table--bordered` instance](https://github.com/texastribune/donations/blob/6ee8c2f81bc947b5e6276ff1f485154a5274c709/static/js/src/entry/account/components/PaymentList.vue#L9) suddenly have borders on all sides if versioned up, but I don't consider that to be disruptive or breaking. My intention is to prevent us from just having a ton of major releases that become daunting to update. I think as long as release notes warn about any subtle style changes, that should be an ok safeguard. I updated the contributing guideline to clarify that.


For those ^ reasons, this will be a minor pre-release to be tested out in the directory feature branches we're working on.

#### TODOs / next steps:

* [ ] *your TODO here*
