### PR TITLE
Add directory utility classes

### DIFF
--- a/assets/scss/6-components/text-input/_text-input.scss
+++ b/assets/scss/6-components/text-input/_text-input.scss
@@ -1,6 +1,6 @@
 // Text input (c-text-input)
 //
-// Text form inputs. Can be used with type="text", type="email", etc. Add .is-valid if the value is not valid.
+// Text form inputs. Can be used with `type="text"`, `type="email"`, etc. Add `.is-valid` if the value is not valid. Use `c-text-input__input--standard` to fix [iOS focus bug](https://stackoverflow.com/questions/2989263/disable-auto-zoom-in-input-text-tag-safari-on-iphone).
 //
 // Markup: 6-components/text-input/text-input.html
 //
@@ -15,6 +15,10 @@
     outline: none;
     padding: $size-xxs;
     transition: box-shadow .15s ease-in-out;
+
+    &--standard {
+      font-size: 16px;
+    }
 
     // kill X button that appears on IE and edge
     // because it doesn't handle JS input event correctly

--- a/assets/scss/7-layout/_position.scss
+++ b/assets/scss/7-layout/_position.scss
@@ -1,9 +1,12 @@
 // Position (l-pos-<setting>)
 //
-// Helper for quickly setting `position: absolute` or `position: relative`. {{isHelper}}
+// Helpers for quickly setting `position`, `z-index`, and `top`. {{isHelper}}
 //
 // .l-pos-rel - Relative position
 // .l-pos-abs - Set _`.l-pos-rel`_ on the parent to place within a defined space.
+// .l-pos-sticky - Tells an element to be fixed once a user scrolls past it
+// .l-pos-top - `top: 0`; We use this in directory, but should find more places where we can use this instead of setting it.
+// .l-pos-front - `z-index: 1`; We use this in directory, but should find more places where we can use this instead of setting it.
 //
 // Markup: 7-layout/position.html
 //
@@ -15,4 +18,17 @@
 
 .l-pos-abs {
   position: absolute;
+}
+
+.l-pos-sticky {
+  position: sticky;
+  z-index: 2;
+}
+
+.l-pos-top {
+  top: 0;
+}
+
+.l-pos-front {
+  z-index: 1;
 }

--- a/assets/scss/7-layout/position.html
+++ b/assets/scss/7-layout/position.html
@@ -8,3 +8,14 @@
     <span class="{{ className }}" style="background-color: #222; color: #fff; padding: 10px; bottom: 0; right: 0; width: 60%;">position: absolute; bottom: 0; right: 0;</span>
   </div>
 {% endif %}
+{% if className == 'l-pos-sticky' %}
+  Demo TK
+{% endif %}
+{% if className == 'l-pos-top' %}
+  <div class="l-pos-rel" style="border: 1px solid #000; width: 300px; height: 100px;">
+    <span class="{{ className }} l-pos-abs" style="background-color: #222; color: #fff; padding: 10px;">position: absolute; top: 0</span>
+  </div>
+{% endif %}
+{% if className == 'l-pos-front' %}
+  Demo TK
+{% endif %}

--- a/assets/scss/utilities/_all.scss
+++ b/assets/scss/utilities/_all.scss
@@ -7,6 +7,7 @@
 @import 'color-helpers';
 @import 'hidden';
 @import 'notch';
+@import 'overflow';
 @import 'rounded';
 @import 'shadows';
 @import 'spacing';

--- a/assets/scss/utilities/_overflow.scss
+++ b/assets/scss/utilities/_overflow.scss
@@ -1,0 +1,13 @@
+// Overflow (has-overflow-x)
+//
+// Used for elements that can scroll left and right usually on mobile. Eventually we could add a variation for the white blurred edge.
+//
+//
+// Markup: <div class="{{ className }} has-bg-gray-light has-padding" style="width:600px;height:150px">Scroll right on mobile</div>
+//
+//
+// Styleguide 8.0.3
+//
+.has-overflow-x {
+  overflow-x: auto;
+}


### PR DESCRIPTION
#### What's this PR do?

Adds more positioning options and builds in a fix for Safari's mobile zoom bug.

##### Classes added (if any)
- c-text-input__input--standard
- l-pos-sticky
- l-pos-top
- l-pos-front
- has-overflow-x
##### Classes removed (if any)
None removed yet, but I think these allow us to delete properties on other components.


#### Why are we doing this? How does it help us?
This was part of the directory refactor. This is will increase CSS file size for now, but I think we can go back and delete a few lines of other class properties in favor of these helpers.


#### How should this be manually tested?
`npm run dev`



#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

Not yet, we'll save the breaking changes where we remove overlapping properties in the next release. Keeping this as part of our directory pre-release.


#### TODOs / next steps:

* [ ] *Clean up any place where these could be used. Topic bar, event block, etc.*
