### PR TITLE
Navbar icon update

### DIFF
--- a/assets/scss/6-components/navbar/_navbar.scss
+++ b/assets/scss/6-components/navbar/_navbar.scss
@@ -17,18 +17,10 @@
   &--light {
     background-color: $color-white-pure;
     border-bottom: 1px solid $color-white-off;
-
-    .c-icon {
-      color: $color-black-off;
-    }
   }
 
   &--dark {
     background-color: $color-black-off;
-
-    .c-icon {
-      color: $color-yellow-tribune;
-    }
   }
 
   &__top {


### PR DESCRIPTION
#### What's this PR do?

Removes the nested c-icon color rule in the navbar component


#### Why are we doing this? How does it help us?

Setting the icon color this way makes it hard to override

#### How should this be manually tested?
`npm run dev`

See: [c-navbar](http://localhost:8080/sections/components/c-navbar/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?
The implications of this is that if you accept this new version, an icon would inherit its color from its ancestor. This is a visual change shouldn't be too disruptive or "breaking" because that's likely the text color, which it's safe to assume would have enough contrast already.

Pairs with: https://github.com/texastribune/texastribune/pull/4725


#### TODOs / next steps:

* [ ] *Update the navbar docs to include light and dark variations*
