### PR TITLE
Add text balance helper ⚖️ 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "conventionalCommits.scopes": [
         "icons",
-        "deps"
+        "deps",
+        "type"
     ]
 }

--- a/assets/scss/5-typography/_t-helpers.scss
+++ b/assets/scss/5-typography/_t-helpers.scss
@@ -121,13 +121,18 @@ $letter-spacing-type: (
 // Helper classes for handling how words are allowed to wrap and break. {{isHelper}}
 //
 // .t-wrap-break - Allow a word to wrap to the next line mid-word
+// .t-wrap-balance - Allow a word to wrap to the next line, but try to keep the lines balanced. This isn't supported in all browsers and could be used in conjunction with our fork of [NYT's balanacer helper](https://github.com/texastribune/text-balancer).
 //
-// Markup: <p class="{{ className }}" style="width: 150px;">barbara.gervin.hawkins@house.texas.gov</p>
+// Markup: 5-typography/wrap.html
 //
 //
 // Styleguide 5.3.6
 .t-wrap-break {
   word-break: break-all;
+}
+
+.t-wrap-balance {
+  text-wrap: balance;
 }
 
 // Text weight (t-weight-<setting>)

--- a/assets/scss/5-typography/wrap.html
+++ b/assets/scss/5-typography/wrap.html
@@ -1,0 +1,5 @@
+{% if className === 't-wrap-break' %}
+<p class="t-wrap-break" style="width: 150px;">barbara.gervin.hawkins@house.texas.gov</p>
+{% else %}
+<p class="{{className}}" style="width: 150px;">The best and worst moments in Texas politics</p>
+{% endif %}


### PR DESCRIPTION
#### What's this PR do?

Adds a new helper for balancing text

##### Classes added (if any)
- t-wrap-balance


#### Why are we doing this? How does it help us?

This is becoming more [supported](https://caniuse.com/css-text-wrap-balance). Tailwind even [recently added](https://tailwindcss.com/blog/tailwindcss-v3-4#balanced-headlines-with-text-wrap-utilities) it as a helper

#### How should this be manually tested?
`npm run dev`

See: [t-wrap](http://localhost:8080/sections/typography/t-wrap-setting/)


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

No it's only additive. It's one more style to load but this will be an overall perf. win on our homepage for browsers that support it. 