### PR TITLE
Flexbox helpers 💪 

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
     "conventionalCommits.scopes": [
         "icons",
-        "deps"
+        "deps",
+        "layout"
     ]
 }

--- a/assets/scss/7-layout/_align-items.scss
+++ b/assets/scss/7-layout/_align-items.scss
@@ -1,0 +1,13 @@
+// Align items (l-ai-<position>)
+//
+// Alignment utilities for flex/grid elements. {{isHelper}}
+//
+// l-ai-center - **align-items: center** Center items vertically (if row).
+//
+// Markup: Parent: <code>display: flex</code> + <code>.{{className}}</code>  <div style="border: 2px solid black; height: 100px; display:flex" class="{{ className }}"><div class="has-bg-yellow has-padding">Child</div></div>
+//
+//
+// Styleguide 7.0.4
+.l-ai-center {
+  align-items: center;
+}

--- a/assets/scss/7-layout/_all.scss
+++ b/assets/scss/7-layout/_all.scss
@@ -4,12 +4,14 @@
 //
 // Styleguide 7.0.0
 @import 'align';
+@import 'align-items';
 @import 'container';
 @import 'col-grid';
 @import 'content-grid';
 @import 'display';
 @import 'flex';
 @import 'height';
+@import 'justify-content';
 @import 'multicol';
 @import 'position';
 @import 'width';

--- a/assets/scss/7-layout/_all.scss
+++ b/assets/scss/7-layout/_all.scss
@@ -8,6 +8,7 @@
 @import 'col-grid';
 @import 'content-grid';
 @import 'display';
+@import 'flex';
 @import 'height';
 @import 'multicol';
 @import 'position';

--- a/assets/scss/7-layout/_flex.scss
+++ b/assets/scss/7-layout/_flex.scss
@@ -1,13 +1,10 @@
 // Flex  (l-flex)
 //
-// Barebones flex helpers. This breaks some convention with other layout classes, but we use flexbox enough to justify it (no pun intended) {{isHelper}}
+// Barebones flex helpers. This breaks some convention with other layout classes, but we use flexbox enough to justify it. <br><br>💡 See [align-items](/sections/layout/l-ai-position/) and [justify-content](/sections/layout/l-jc-position/) helpers for alignment helpers. {{isHelper}}
 //
 // .l-flex - **display:flex** Uses flexbox.
-// .l-flex-row - **flex-direction: row** Horizontal flexbox.
+// .l-flex-row - **flex-direction: row** Horizontal flexbox. (default)
 // .l-flex-column - **flex-direction: column** Vertical flexbox.
-// .l-flex-ai-center - **align-items: center** Center items vertically (for row).
-// .l-flex-jc-center - **justify-content: center** Center items horizontally (for row).
-// .l-flex-jc-space - **justify-content: space-between** Evenly space items horizontally (for row).
 //
 // Markup: 7-layout/flex.html
 // 
@@ -24,16 +21,4 @@
 
 .l-flex-column {
   flex-direction: column;
-}
-
-.l-flex-ai-center {
-  align-items: center;
-}
-
-.l-flex-jc-center {
-  justify-content: center;
-}
-
-.l-flex-jc-space {
-  justify-content: space-between;
 }

--- a/assets/scss/7-layout/_flex.scss
+++ b/assets/scss/7-layout/_flex.scss
@@ -5,8 +5,9 @@
 // .l-flex - **display:flex** Uses flexbox.
 // .l-flex-row - **flex-direction: row** Horizontal flexbox.
 // .l-flex-column - **flex-direction: column** Vertical flexbox.
-// .l-flex-center-items - **align-items: center** Center items vertically (for row).
-// .l-flex-center-content - **justify-content: center** Center items horizontally (for row).
+// .l-flex-ai-center - **align-items: center** Center items vertically (for row).
+// .l-flex-jc-center - **justify-content: center** Center items horizontally (for row).
+// .l-flex-jc-space - **justify-content: space-between** Evenly space items horizontally (for row).
 //
 // Markup: 7-layout/flex.html
 // 
@@ -25,10 +26,14 @@
   flex-direction: column;
 }
 
-.l-flex-center-items {
+.l-flex-ai-center {
   align-items: center;
 }
 
-.l-flex-center-content {
+.l-flex-jc-center {
   justify-content: center;
+}
+
+.l-flex-jc-space {
+  justify-content: space-between;
 }

--- a/assets/scss/7-layout/_flex.scss
+++ b/assets/scss/7-layout/_flex.scss
@@ -1,0 +1,34 @@
+// Flex  (l-flex)
+//
+// Barebones flex helpers. This breaks some convention with other layout classes, but we use flexbox enough to justify it (no pun intended) {{isHelper}}
+//
+// .l-flex - **display:flex** Uses flexbox.
+// .l-flex-row - **flex-direction: row** Horizontal flexbox.
+// .l-flex-column - **flex-direction: column** Vertical flexbox.
+// .l-flex-center-items - **align-items: center** Center items vertically (for row).
+// .l-flex-center-content - **justify-content: center** Center items horizontally (for row).
+//
+// Markup: 7-layout/flex.html
+// 
+//
+// Styleguide 7.0.4
+
+.l-flex {
+  display: flex;
+}
+
+.l-flex-row {
+  flex-direction: row;
+}
+
+.l-flex-column {
+  flex-direction: column;
+}
+
+.l-flex-center-items {
+  align-items: center;
+}
+
+.l-flex-center-content {
+  justify-content: center;
+}

--- a/assets/scss/7-layout/_justify-content.scss
+++ b/assets/scss/7-layout/_justify-content.scss
@@ -1,0 +1,18 @@
+// Justify content (l-jc-<position>)
+//
+// Alignment utilities for flex/grid elements. {{isHelper}}
+//
+// l-jc-center - **align-items: center** Center items horizontally (if row).
+// l-jc-space - **justify-content: space-between** Evenly space items horizontally (if row).
+//
+// Markup: Parent: <code>display: flex</code> + <code>.{{className}}</code>  <div style="border: 2px solid black; height: 100px; display:grid" class="{{ className }}"><div class="has-bg-yellow has-padding">Child</div><div class="has-bg-black has-text-white has-padding">Child</div></div>
+//
+//
+// Styleguide 7.0.4
+.l-jc-center {
+  justify-content: center;
+}
+
+.l-jc-space {
+  justify-content: space-between;
+}

--- a/assets/scss/7-layout/_justify-content.scss
+++ b/assets/scss/7-layout/_justify-content.scss
@@ -5,7 +5,7 @@
 // l-jc-center - **align-items: center** Center items horizontally (if row).
 // l-jc-space - **justify-content: space-between** Evenly space items horizontally (if row).
 //
-// Markup: Parent: <code>display: flex</code> + <code>.{{className}}</code>  <div style="border: 2px solid black; height: 100px; display:grid" class="{{ className }}"><div class="has-bg-yellow has-padding">Child</div><div class="has-bg-black has-text-white has-padding">Child</div></div>
+// Markup: Parent: <code>display: flex</code> + <code>.{{className}}</code>  <div style="border: 2px solid black; height: 100px; display:flex" class="{{ className }}"><div class="has-bg-yellow has-padding">Child</div><div class="has-bg-black has-text-white has-padding">Child</div></div>
 //
 //
 // Styleguide 7.0.4

--- a/assets/scss/7-layout/flex.html
+++ b/assets/scss/7-layout/flex.html
@@ -1,0 +1,11 @@
+{% if className == 'l-flex' %}
+    <div class="has-padding {{className}}">
+        <div class="has-bg-black has-text-white" style="width: 150px; height: 150px;">1</div>
+        <div class="has-bg-yellow" style="width: 150px; height: 150px;">2</div>
+    </div>    
+{% else %}
+<div class="has-padding has-section-padding has-border l-flex {{className}}">
+    <div class="has-bg-black has-text-white" style="width: 150px; height: 150px;">1</div>
+    <div class="has-bg-yellow" style="width: 150px; height: 150px;">2</div>
+  </div>
+{% endif %}


### PR DESCRIPTION
#### What's this PR do?

Adds some super basic flexbox classes

##### Classes added (if any)
- .l-flex - **display:flex** Uses flexbox.
- .l-flex-row - **flex-direction: row** Horizontal flexbox.
- .l-flex-column - **flex-direction: column** Vertical flexbox.
- .l-ai-center - **align-items: center** Center items vertically (for row).
- .l-jc-center - **justify-content: center** Center items horizontally (for row).
- .l-jc-space - **justify-content: space-between** Evenly space items horizontally (for row).


#### Why are we doing this? How does it help us?

In theory, it will shave some lines from our current CSS

- display: flex - [found about 24 times](https://github.com/search?q=repo:texastribune/texastribune+display:+flex+language:SCSS&type=code&l=SCSS&p=1)
- flex-direction: row - [found about 6 times](https://github.com/search?q=repo:texastribune/texastribune+flex-direction:+row+language:SCSS&type=code)
- flex-direction: column - [found about 7 times](https://github.com/search?q=repo:texastribune/texastribune+flex-direction:+column+language:SCSS&type=code)
- align-items: center - [found about 15 times](https://github.com/search?q=repo:texastribune/texastribune+align-items:+center+language:SCSS&type=code)
- justify-content: center - [found about 10 times](https://github.com/search?q=repo:texastribune/texastribune+justify-content:+center+language:SCSS&type=code)

This may result in minimal bytes saved in the end, but hopefully helps us for future elements!

#### Why aren't there more?

I refrained from adding _every_ utility one might need for flexbox and went with the ones I saw the most and that'd be most consistent. For instance a `gap:` helper would vary in what size value you want and other alignments like `align-items: flex-start` seem less frequent 

This also shoots us in the foot a little in terms of naming if we got more `display grid` happy in the future. 

#### How should this be manually tested?
`npm run dev`

See: `/sections/layout/l-flex/`


#### Does this introduce a breaking change where queso-ui is used in the wild? If so, is there a relevant branch/PR to accompany this release?

I'll tackle the texastribune PR (which is just a find and replace in HTML/CSS) when this is released. The new queso release won't hurt/change anything on its own.
